### PR TITLE
Use rollup for publish build... didn't need this

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "start:publish:debug": "ts-node --inspect=5858 --debug-brk --ignore false src/microapps-publish/src/index.ts",
     "build": "tsc --build tsconfig.json",
     "build:deployer": "rollup --config rollup.deployer.js",
+    "build:publish": "rollup --config rollup.publish.js",
     "build:router": "rollup --config rollup.router.js && cp src/microapps-router/appFrame.html distb/microapps-router/",
     "test:trash": "start-server-and-test test:dynamodb http-get://localhost:8000/ test:mocha",
     "test:dynamodb": "local-dynamodb",

--- a/rollup.publish.js
+++ b/rollup.publish.js
@@ -1,0 +1,40 @@
+import commonjs from '@rollup/plugin-commonjs';
+import typescript from 'rollup-plugin-typescript2';
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import externals from 'rollup-plugin-node-externals';
+import json from '@rollup/plugin-json';
+import { terser } from 'rollup-plugin-terser';
+
+const LOCAL_EXTERNALS = [];
+const NPM_EXTERNALS = [];
+
+const generateConfig = (input) => ({
+  input: `./src/microapps-publish/src/${input.filename}.ts`,
+  output: {
+    file: `./distb/microapps-publish/${input.filename}${input.minify ? '' : '.max'}.js`,
+    format: 'cjs',
+  },
+  plugins: [
+    json(),
+    commonjs(),
+    externals({}),
+    nodeResolve(),
+    typescript({
+      tsconfig: 'tsconfig.bundle-publish.json',
+    }),
+    input.minify
+      ? terser({
+        compress: true,
+        mangle: true,
+        output: { comments: false }, // Remove all comments, which is fine as the handler code is not distributed.
+      })
+      : undefined,
+  ],
+  external: [...NPM_EXTERNALS, ...LOCAL_EXTERNALS],
+  inlineDynamicImports: true,
+});
+
+export default [
+  { filename: 'index', minify: false },
+  { filename: 'index', minify: true },
+].map(generateConfig);

--- a/tsconfig.bundle-publish.json
+++ b/tsconfig.bundle-publish.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "target": "es2017",
+    "moduleResolution": "node",
+    "noImplicitAny": true,
+    "sourceMap": true,
+    "strict": false,
+    "allowJs": true,
+    "resolveJsonModule": true
+  },
+  "include": ["./src/microapps-publish/src/index.ts"]
+}


### PR DESCRIPTION
- This didn't turn out to be particularly helpful for an `npm` executable