### PR TITLE
Remove use of tscp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,11 +168,15 @@ jobs:
       - name: Build All TypeScript
         run: npm run build:publish --if-present
 
-      - name: Copy other files for publishing - microapps-publish
-        run: cd src/microapps-publish && npx tscp
+      # - name: Copy other files for publishing - microapps-publish
+      #   run: |
+      #     cd src/microapps-publish
+      #     npx tscp
 
-      - name: Copy other files for publishing - microapps-datalib
-        run: cd src/common/microapps-datalib && npx tscp
+      # - name: Copy other files for publishing - microapps-datalib
+      #   run: |
+      #     cd src/common/microapps-datalib
+      #     npx tscp
 
       - name: Run Lint
         run: npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -20193,7 +20193,8 @@
         "@types/fs-extra": "^9.0.11",
         "@types/js-yaml": "^4.0.1",
         "@types/mime-types": "^2.1.0",
-        "@types/source-map-support": "^0.5.4"
+        "@types/source-map-support": "^0.5.4",
+        "type-fest": "^0.20.2"
       }
     },
     "src/microapps-publish/node_modules/argparse": {
@@ -23495,7 +23496,8 @@
         "reflect-metadata": "^0.1.13",
         "source-map-support": "^0.5.19",
         "ts-convict": "^1.1.0",
-        "tslib": "^2.1.0"
+        "tslib": "^2.1.0",
+        "type-fest": "^0.20.2"
       },
       "dependencies": {
         "argparse": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4607,12 +4607,6 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
     },
-    "node_modules/@types/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-      "dev": true
-    },
     "node_modules/@types/prettier": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz",
@@ -7952,40 +7946,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
-    },
-    "node_modules/cosmiconfig": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/cosmiconfig/node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -19266,114 +19226,6 @@
         "node": ">=4.2.0"
       }
     },
-    "node_modules/typescript-cp": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/typescript-cp/-/typescript-cp-0.1.4.tgz",
-      "integrity": "sha512-RGXZzFFUjFkifIrk7UA/OJmj2XLxyn/aTQKkiuydO2aWvVIsFgF+wdu9rtwqLmXQK8ERHrozqAX1tEz6JATp1w==",
-      "dev": true,
-      "dependencies": {
-        "chokidar": "^3.5.1",
-        "commander": "^8.1.0",
-        "cosmiconfig": "^7.0.0",
-        "fs-extra": "^10.0.0",
-        "globby": "^11.0.3",
-        "lodash": "^4.17.21",
-        "pify": "^5.0.0",
-        "rimraf": "^3.0.2",
-        "tar": "^6.1.0"
-      },
-      "bin": {
-        "tscp": "dist/bin/tscp.js"
-      },
-      "peerDependencies": {
-        "typescript": "^4.2.3"
-      }
-    },
-    "node_modules/typescript-cp/node_modules/commander": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.2.0.tgz",
-      "integrity": "sha512-LLKxDvHeL91/8MIyTAD5BFMNtoIwztGPMiM/7Bl8rIPmHCZXRxmSWr91h57dpOpnQ6jIUqEWdXE/uBYMfiVZDA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/typescript-cp/node_modules/fs-extra": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/typescript-cp/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/typescript-cp/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/typescript-cp/node_modules/pify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
-      "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/typescript-cp/node_modules/tar": {
-      "version": "6.1.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-      "dev": true,
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^3.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/typescript-cp/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -20004,15 +19856,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
-    "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -20144,8 +19987,7 @@
         "chai": "^4.3.4",
         "dynamodb-local": "^0.0.31",
         "mocha": "^8.3.0",
-        "node-fetch": "^2.6.1",
-        "typescript-cp": "^0.1.4"
+        "node-fetch": "^2.6.1"
       },
       "peerDependencies": {
         "@aws-sdk/client-dynamodb": "^3.20.0",
@@ -20351,8 +20193,7 @@
         "@types/fs-extra": "^9.0.11",
         "@types/js-yaml": "^4.0.1",
         "@types/mime-types": "^2.1.0",
-        "@types/source-map-support": "^0.5.4",
-        "typescript-cp": "^0.1.4"
+        "@types/source-map-support": "^0.5.4"
       }
     },
     "src/microapps-publish/node_modules/argparse": {
@@ -23542,8 +23383,7 @@
         "class-transformer": "^0.4.0",
         "dynamodb-local": "^0.0.31",
         "mocha": "^8.3.0",
-        "node-fetch": "^2.6.1",
-        "typescript-cp": "^0.1.4"
+        "node-fetch": "^2.6.1"
       }
     },
     "@pwrdrvr/microapps-deployer": {
@@ -23655,8 +23495,7 @@
         "reflect-metadata": "^0.1.13",
         "source-map-support": "^0.5.19",
         "ts-convict": "^1.1.0",
-        "tslib": "^2.1.0",
-        "typescript-cp": "^0.1.4"
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "argparse": {
@@ -24101,12 +23940,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
-    },
-    "@types/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-      "dev": true
     },
     "@types/prettier": {
       "version": "2.3.2",
@@ -26646,33 +26479,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
-    },
-    "cosmiconfig": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
-      "dev": true,
-      "requires": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "dependencies": {
-        "parse-json": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-          "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "error-ex": "^1.3.1",
-            "json-parse-even-better-errors": "^2.3.0",
-            "lines-and-columns": "^1.1.6"
-          }
-        }
-      }
     },
     "create-require": {
       "version": "1.1.1",
@@ -35268,84 +35074,6 @@
       "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "devOptional": true
     },
-    "typescript-cp": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/typescript-cp/-/typescript-cp-0.1.4.tgz",
-      "integrity": "sha512-RGXZzFFUjFkifIrk7UA/OJmj2XLxyn/aTQKkiuydO2aWvVIsFgF+wdu9rtwqLmXQK8ERHrozqAX1tEz6JATp1w==",
-      "dev": true,
-      "requires": {
-        "chokidar": "^3.5.1",
-        "commander": "^8.1.0",
-        "cosmiconfig": "^7.0.0",
-        "fs-extra": "^10.0.0",
-        "globby": "^11.0.3",
-        "lodash": "^4.17.21",
-        "pify": "^5.0.0",
-        "rimraf": "^3.0.2",
-        "tar": "^6.1.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-8.2.0.tgz",
-          "integrity": "sha512-LLKxDvHeL91/8MIyTAD5BFMNtoIwztGPMiM/7Bl8rIPmHCZXRxmSWr91h57dpOpnQ6jIUqEWdXE/uBYMfiVZDA==",
-          "dev": true
-        },
-        "fs-extra": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-          "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          }
-        },
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "dev": true
-        },
-        "pify": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
-          "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
-          "dev": true
-        },
-        "tar": {
-          "version": "6.1.11",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-          "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-          "dev": true,
-          "requires": {
-            "chownr": "^2.0.0",
-            "fs-minipass": "^2.0.0",
-            "minipass": "^3.0.0",
-            "minizlib": "^2.1.1",
-            "mkdirp": "^1.0.3",
-            "yallist": "^4.0.0"
-          }
-        },
-        "universalify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-          "dev": true
-        }
-      }
-    },
     "unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -35847,12 +35575,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
-    "yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true
     },
     "yargs": {
       "version": "16.2.0",

--- a/src/common/microapps-datalib/.npmignore
+++ b/src/common/microapps-datalib/.npmignore
@@ -1,1 +1,1 @@
-tsconfig.tsbuildinfo
+*.tsbuildinfo

--- a/src/common/microapps-datalib/package.json
+++ b/src/common/microapps-datalib/package.json
@@ -38,8 +38,7 @@
     "chai": "^4.3.4",
     "dynamodb-local": "^0.0.31",
     "mocha": "^8.3.0",
-    "node-fetch": "^2.6.1",
-    "typescript-cp": "^0.1.4"
+    "node-fetch": "^2.6.1"
   },
   "files": [
     "dist",

--- a/src/microapps-publish/.npmignore
+++ b/src/microapps-publish/.npmignore
@@ -1,2 +1,2 @@
 static/
-*.buildinfo
+*.tsbuildinfo

--- a/src/microapps-publish/package.json
+++ b/src/microapps-publish/package.json
@@ -57,7 +57,6 @@
     "@types/fs-extra": "^9.0.11",
     "@types/js-yaml": "^4.0.1",
     "@types/mime-types": "^2.1.0",
-    "@types/source-map-support": "^0.5.4",
-    "typescript-cp": "^0.1.4"
+    "@types/source-map-support": "^0.5.4"
   }
 }

--- a/src/microapps-publish/package.json
+++ b/src/microapps-publish/package.json
@@ -57,6 +57,7 @@
     "@types/fs-extra": "^9.0.11",
     "@types/js-yaml": "^4.0.1",
     "@types/mime-types": "^2.1.0",
-    "@types/source-map-support": "^0.5.4"
+    "@types/source-map-support": "^0.5.4",
+    "type-fest": "^0.20.2"
   }
 }

--- a/src/microapps-publish/src/index.ts
+++ b/src/microapps-publish/src/index.ts
@@ -5,12 +5,13 @@ import 'source-map-support/register';
 // Used by ts-convict
 import 'reflect-metadata';
 import { exec } from 'child_process';
-import * as fs from 'fs/promises';
+import { join as pathJoin } from 'path';
 import * as util from 'util';
 import * as lambda from '@aws-sdk/client-lambda';
 import * as sts from '@aws-sdk/client-sts';
 import commander from 'commander';
-import pkg from '../package.json';
+import { promises as fs, readJsonSync } from 'fs-extra';
+import type { PackageJson } from 'type-fest';
 import { Config, IConfig } from './config/Config';
 import DeployClient from './DeployClient';
 import S3Uploader from './S3Uploader';
@@ -18,6 +19,8 @@ const asyncSetTimeout = util.promisify(setTimeout);
 const asyncExec = util.promisify(exec);
 
 const program = new commander.Command();
+
+const pkg: PackageJson = readJsonSync(pathJoin(__dirname, '..', 'package.json'));
 
 program
   .version(pkg.version)

--- a/src/microapps-publish/tsconfig.json
+++ b/src/microapps-publish/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.packages.json",
   "compilerOptions": {
-    "rootDir": ".",
+    "rootDir": "src",
     "outDir": "dist",
     "strict": false,
     "resolveJsonModule": true

--- a/src/microapps-publish/tsconfig.json
+++ b/src/microapps-publish/tsconfig.json
@@ -3,9 +3,7 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
-    "strict": false,
-    "resolveJsonModule": true
+    "strict": false
   },
-  "include": ["package.json", "src/**/*.ts"],
   "exclude": ["**/*.spec.ts", "dist"]
 }

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -14,7 +14,6 @@
     "noImplicitThis": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "resolveJsonModule": true,
     "strict": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,


### PR DESCRIPTION
- Remove `typescript-cp`
- Change `rootDir` for microapps-publish from `.` to `src`
- Overall: trying to flatten and simplify the packaging structure
- Load `package.json` in `microapps-publish` via API call instead of as JSON Module