### PR TITLE
Detect deployer failure due to lack of API Gateway permissions

### DIFF
--- a/packages/microapps-deployer/src/config/APIGateway.ts
+++ b/packages/microapps-deployer/src/config/APIGateway.ts
@@ -1,7 +1,15 @@
 import { Property } from 'ts-convict';
 
 export interface IAPIGateway {
+  /**
+   * @deprecated - 2021-11-28 - Use apiId instead
+   */
   name: string;
+
+  /**
+   * ID of the API Gateway to integrate with
+   */
+  apiId: string;
 }
 
 export class APIGateway implements IAPIGateway {
@@ -11,4 +19,12 @@ export class APIGateway implements IAPIGateway {
     env: 'APIGWY_NAME',
   })
   public name!: string;
+
+  @Property({
+    doc: 'ID of API Gateway to integrate with',
+    nullable: false,
+    default: 'none',
+    env: 'APIGWY_ID',
+  })
+  public apiId!: string;
 }

--- a/packages/microapps-deployer/src/controllers/AppController.ts
+++ b/packages/microapps-deployer/src/controllers/AppController.ts
@@ -1,12 +1,22 @@
 import { Application, DBManager } from '@pwrdrvr/microapps-datalib';
 import { ICreateApplicationRequest, IDeployerResponse } from '@pwrdrvr/microapps-deployer-lib';
 
+function isNil(arg: string | undefined | null) {
+  if (arg === undefined || arg === null || arg === '') return true;
+  return false;
+}
+
 export default class AppController {
   public static async CreateApp(opts: {
     dbManager: DBManager;
     app: ICreateApplicationRequest;
   }): Promise<IDeployerResponse> {
     const { dbManager, app } = opts;
+
+    // TODO: Use a schema validator
+    if (isNil(app.appName) || isNil(app.displayName) || isNil(app.type)) {
+      return { statusCode: 400 };
+    }
 
     const response = await Application.Load({ dbManager, key: { AppName: app.appName } });
 

--- a/packages/microapps-deployer/src/index.spec.ts
+++ b/packages/microapps-deployer/src/index.spec.ts
@@ -15,6 +15,7 @@ Object.defineProperty(Config, 'instance', {
         tableName: 'microapps',
       },
       apigwy: {
+        apiId: '123',
         name: 'microapps-test',
       },
       filestore: {

--- a/packages/microapps-deployer/src/index.spec.ts
+++ b/packages/microapps-deployer/src/index.spec.ts
@@ -1,0 +1,120 @@
+// index.test.ts
+/// <reference types="jest" />
+import 'reflect-metadata';
+import 'jest-dynalite/withDb';
+import { Config, IConfig } from './config/Config';
+jest.mock('./config/Config');
+Object.defineProperty(Config, 'instance', {
+  configurable: false,
+  enumerable: false,
+  get: jest.fn((): IConfig => {
+    return {
+      awsAccountID: 123456,
+      awsRegion: 'mock',
+      db: {
+        tableName: 'microapps',
+      },
+      apigwy: {
+        name: 'microapps-test',
+      },
+      filestore: {
+        stagingBucket: 'microapps-test-staging',
+        destinationBucket: 'microapps-test-destination',
+      },
+      uploadRoleName: 'microapps-upload-test-role',
+    };
+  }),
+});
+import * as dynamodb from '@aws-sdk/client-dynamodb';
+import { mockClient, AwsClientStub } from 'aws-sdk-client-mock';
+import { handler, overrideDBManager } from './index';
+import { Application, DBManager } from '@pwrdrvr/microapps-datalib';
+import { ICreateApplicationRequest } from '@pwrdrvr/microapps-deployer-lib';
+
+let dynamoClient: dynamodb.DynamoDBClient;
+let dbManager: DBManager;
+
+describe('deployer handler', () => {
+  const config = Config.instance;
+
+  beforeEach(() => {
+    overrideDBManager({ dbManager, dynamoClient });
+  });
+
+  beforeAll(() => {
+    dynamoClient = new dynamodb.DynamoDBClient({
+      endpoint: process.env.MOCK_DYNAMODB_ENDPOINT,
+      tls: false,
+      region: 'local',
+    });
+
+    // Init the DB manager to point it at the right table
+    dbManager = new DBManager({ dynamoClient, tableName: config.db.tableName });
+  });
+
+  afterAll(() => {
+    dynamoClient.destroy();
+  }, 20000);
+
+  describe('application create', () => {
+    it('application create - valid', async () => {
+      // Confirm that app does not exist
+      let app = await Application.Load({ dbManager, key: { AppName: 'test-app' } });
+      expect(app).toBeUndefined();
+
+      // Create the app
+      const payload: ICreateApplicationRequest = {
+        appName: 'test-app',
+        displayName: 'NewDisplayName',
+        type: 'createApp',
+      };
+      const result = await handler(payload);
+
+      expect(result).toBeDefined();
+      expect(result.statusCode).toBe(201);
+
+      // Check that app exists
+      app = await Application.Load({ dbManager, key: { AppName: 'test-app' } });
+      expect(app).toBeDefined();
+      expect(app.AppName).toBe('test-app');
+    });
+
+    it('application create - missing type', async () => {
+      // Confirm that app does not exist
+      let app = await Application.Load({ dbManager, key: { AppName: 'test-app' } });
+      expect(app).toBeUndefined();
+
+      // Fail to create an app
+      const payload: ICreateApplicationRequest = {
+        appName: 'test-app',
+      } as ICreateApplicationRequest;
+      const result = await handler(payload);
+
+      expect(result).toBeDefined();
+      expect(result.statusCode).toBe(400);
+
+      // Check that app does not exist
+      app = await Application.Load({ dbManager, key: { AppName: 'test-app' } });
+      expect(app).toBeUndefined();
+    });
+
+    it('application create - missing other fields', async () => {
+      // Confirm that app does not exist
+      let app = await Application.Load({ dbManager, key: { AppName: 'test-app' } });
+      expect(app).toBeUndefined();
+
+      // Fail to create an app
+      const payload: ICreateApplicationRequest = {
+        type: 'createApp',
+      } as ICreateApplicationRequest;
+      const result = await handler(payload);
+
+      expect(result).toBeDefined();
+      expect(result.statusCode).toBe(400);
+
+      // Check that app does not exist
+      app = await Application.Load({ dbManager, key: { AppName: 'test-app' } });
+      expect(app).toBeUndefined();
+    });
+  });
+});

--- a/packages/microapps-deployer/src/index.ts
+++ b/packages/microapps-deployer/src/index.ts
@@ -37,7 +37,7 @@ const config = Config.instance;
 
 export async function handler(
   event: IRequestBase,
-  context: lambda.Context,
+  context?: lambda.Context,
 ): Promise<IDeployerResponse> {
   if (dbManager === undefined) {
     dbManager = new DBManager({
@@ -61,7 +61,7 @@ export async function handler(
     debug: localTesting,
     meta: {
       source: 'microapps-deployer',
-      awsRequestId: context.awsRequestId,
+      awsRequestId: context?.awsRequestId,
       requestType: event.type,
     },
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -89,18 +89,13 @@ export async function handler(
         const request = event as IDeployVersionRequest;
         return await VersionController.DeployVersion({ dbManager, request, config });
       }
+
+      default:
+        return { statusCode: 400 };
     }
   } catch (err) {
     Log.Instance.error('Caught unexpected exception in handler');
     Log.Instance.error(err);
     return { statusCode: 500 };
   }
-}
-
-// Run the function locally for testing
-if (localTesting) {
-  const payload = { appName: 'test-app' } as ICreateApplicationRequest;
-  void Promise.all([
-    handler(payload as IRequestBase, { awsRequestId: 'local-testing' } as lambda.Context),
-  ]);
 }

--- a/packages/microapps-deployer/src/lib/GatewayInfo.ts
+++ b/packages/microapps-deployer/src/lib/GatewayInfo.ts
@@ -1,21 +1,23 @@
 import * as apigwy from '@aws-sdk/client-apigatewayv2';
-import { Config } from '../config/Config';
 
 export default class GatewayInfo {
-  // public static async GetAPIID(apigwyClient: apigwy.ApiGatewayV2Client): Promise<string> {
-  //   return (await GatewayInfo.GetAPI(apigwyClient))?.ApiId as string;
-  // }
-
-  public static async GetAPI(
-    apigwyClient: apigwy.ApiGatewayV2Client,
-  ): Promise<apigwy.Api | undefined> {
+  /**
+   * Find first API by name - This is not reliable
+   * @deprecated 2021-11-28 - Do NOT use as this will return first matching name, which can have duplicates
+   * @param apigwyClient
+   * @returns
+   */
+  public static async GetAPI(opts: {
+    apigwyClient: apigwy.ApiGatewayV2Client;
+    apiName: string;
+  }): Promise<apigwy.Api | undefined> {
     let apis: apigwy.GetApisCommandOutput | undefined;
     do {
       const optionals =
         apis?.NextToken !== undefined
           ? { NextToken: apis.NextToken }
           : ({} as apigwy.GetApisCommandInput);
-      apis = await apigwyClient.send(
+      apis = await opts.apigwyClient.send(
         new apigwy.GetApisCommand({
           MaxResults: '100',
           ...optionals,
@@ -31,7 +33,7 @@ export default class GatewayInfo {
 
       // Loop through and find our item, it it is here
       for (const api of apis.Items) {
-        if (api.Name === Config.instance.apigwy.name) {
+        if (api.Name === opts.apiName) {
           return api;
         }
       }

--- a/packages/microapps-publish/src/DeployClient.ts
+++ b/packages/microapps-publish/src/DeployClient.ts
@@ -78,6 +78,14 @@ export default class DeployClient {
     }
   }
 
+  /**
+   * Copy S3 static assets from staging to live bucket.
+   * Create API Gateway Integration for app (if needed).
+   * Give API Gateway permission to call the Lambda.
+   * Create API Gateway routes for this specific version.
+   * @param config
+   * @param task
+   */
   public static async DeployVersion(
     config: IConfig,
     task: TaskWrapper<IContext, typeof DefaultRenderer>,
@@ -104,6 +112,7 @@ export default class DeployClient {
         task.output = `Deploy succeeded: ${config.app.name}/${config.app.semVer}`;
       } else {
         task.output = `Deploy failed with: ${dResponse.statusCode}`;
+        throw new Error(`Lambda call to DeployVersionfailed with: ${dResponse.statusCode}`);
       }
     } else {
       throw new Error(`Lambda call to DeployVersion failed: ${JSON.stringify(response)}`);


### PR DESCRIPTION
- Pass API Gateway ID to the Deployer function, instead of just the name
- Skip the API Gateway lookup by name in Deployer function
- Detect API Gateway permission failure in Deployer as a 401 instead of a 500
- `microapps-publish` - Abort the deploy and log if Deployer returns 401 or 500 status code