### PR TITLE
Add policies if they do not exist and never remove

### DIFF
--- a/packages/microapps-cdk/src/MicroAppsSvcs.ts
+++ b/packages/microapps-cdk/src/MicroAppsSvcs.ts
@@ -397,15 +397,13 @@ export class MicroAppsSvcs extends cdk.Construct implements IMicroAppsSvcsExport
     const policyCloudFrontAccess = new iam.PolicyStatement({
       sid: 'cloudfront-oai-access',
       effect: iam.Effect.ALLOW,
-      // ListBucket is needed so that missing assets
-      // return a 404 NotFound instead of a 403 AccessDenied
-      actions: ['s3:GetObject', 's3:ListBucket'],
+      actions: ['s3:GetObject'],
       principals: [
         new iam.CanonicalUserPrincipal(
           bucketAppsOAI.cloudFrontOriginAccessIdentityS3CanonicalUserId,
         ),
       ],
-      resources: [`${bucketApps.bucketArn}/*`, bucketApps.bucketArn],
+      resources: [`${bucketApps.bucketArn}/*`],
     });
     if (bucketApps.policy === undefined) {
       const document = new s3.BucketPolicy(this, 'CFPolicy', {

--- a/packages/microapps-deployer/src/controllers/VersionController.spec.ts
+++ b/packages/microapps-deployer/src/controllers/VersionController.spec.ts
@@ -187,9 +187,12 @@ describe('VersionController', () => {
       lambdaClient
         .onAnyCommand()
         .rejects()
-        // Mock permission removes - these can fail
-        .on(lambda.RemovePermissionCommand)
-        .rejects()
+        .on(lambda.GetPolicyCommand, {
+          FunctionName: fakeLambdaARN,
+        })
+        .rejects({
+          name: 'ResourceNotFoundException',
+        })
         // Mock permission add for version root
         .on(lambda.AddPermissionCommand, {
           Principal: 'apigateway.amazonaws.com',
@@ -288,9 +291,23 @@ describe('VersionController', () => {
       lambdaClient
         .onAnyCommand()
         .rejects()
-        // Mock permission removes - these can fail
-        .on(lambda.RemovePermissionCommand)
-        .rejects()
+        .on(lambda.GetPolicyCommand, {
+          FunctionName: fakeLambdaARN,
+        })
+        .resolves({
+          Policy: JSON.stringify({
+            Version: '2012-10-17',
+            Id: 'default',
+            Statement: [
+              {
+                Sid: 'microapps-version-root',
+              },
+              {
+                Sid: 'microapps-version',
+              },
+            ],
+          }),
+        })
         // Mock permission add for version root
         .on(lambda.AddPermissionCommand, {
           Principal: 'apigateway.amazonaws.com',
@@ -391,9 +408,12 @@ describe('VersionController', () => {
       lambdaClient
         .onAnyCommand()
         .rejects()
-        // Mock permission removes - these can fail
-        .on(lambda.RemovePermissionCommand)
-        .rejects()
+        .on(lambda.GetPolicyCommand, {
+          FunctionName: fakeLambdaARN,
+        })
+        .rejects({
+          name: 'ResourceNotFoundException',
+        })
         // Mock permission add for version root
         .on(lambda.AddPermissionCommand, {
           Principal: 'apigateway.amazonaws.com',
@@ -510,10 +530,12 @@ describe('VersionController', () => {
       lambdaClient
         .onAnyCommand()
         .rejects()
-        // Mock permission removes - these can fail
-        .on(lambda.RemovePermissionCommand)
-        .rejects()
-
+        .on(lambda.GetPolicyCommand, {
+          FunctionName: fakeLambdaARN,
+        })
+        .rejects({
+          name: 'ResourceNotFoundException',
+        })
         // Mock permission add for version root
         .on(lambda.AddPermissionCommand, {
           Principal: 'apigateway.amazonaws.com',


### PR DESCRIPTION
- Fixes #156
- Policies were previously being removed from a specific Lambda alias then being re-added on each deploy
- An overwrite of an existing app version would cause the app version to be momentarily unavailable during the overwrite