### PR TITLE
Split jsii build to parallel step

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -43,14 +43,46 @@ jobs:
       - name: Install Node Modules
         run: npm ci
 
+      - name: Build All TypeScript
+        run: npm run build --if-present
+    
+      - name: Run Lint
+        run: npm run lint
+
+      - name: Run Node Tests
+        run: npm run test
+      
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-session-name: microapps-core-build
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/RoleForGitHub
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Deploy CDK Stack
+        run: npx cdk deploy --hotswap --require-approval never microapps-core
+
+  build-jsii:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js 16
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: Install Node Modules
+        run: npm ci
+
       # Projen keeps creating `packages/microapps-cdk/test/hello.test.ts`
       - name: Generate Projen Files
         working-directory: packages/microapps-cdk/
         run: |
           npx projen --version
           npm run projen
-          ls -la test/
-          cat test/hello.test.ts
           rm test/hello.test.ts
 
       - name: Modify microapps-cdk tsconfig.json
@@ -76,19 +108,3 @@ jobs:
         run: |
           npm ci
           npm run build
-
-      # - name: Bundle Deployer
-      #   run: npm run esbuild:deployer
-
-      # - name: Bundle Router
-      #   run: npm run esbuild:router
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-session-name: microapps-core-build
-          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/RoleForGitHub
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Deploy CDK Stack
-        run: npx cdk deploy --require-approval never microapps-core

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -93,13 +93,6 @@ jobs:
       - name: Build All TypeScript
         run: npm run build --if-present
     
-      - name: Run Lint
-        run: npm run lint
-
-      - name: Run Node Tests
-        run: |
-          npm run test
-
       - name: Move root modules out of the way for CDK Construct build
         run: mv node_modules node_modules_hide
       


### PR DESCRIPTION
- Let's not wait for the extra time needed to build Java / C# / Python just to get our CDK stack deployed