### PR TITLE
Route _next/data/semver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      statuses: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
         uses: Sibz/github-status-action@v1
         with: 
           authToken: ${{secrets.GITHUB_TOKEN}}
-          context: 'Demo App URL on MicroApps'
+          context: 'Demo App URL on ${{ matrix.deployName }}'
           description: 'Passed'
           state: 'success'
           sha: ${{github.event.pull_request.head.sha || github.sha}}
@@ -248,7 +248,7 @@ jobs:
         uses: Sibz/github-status-action@v1
         with: 
           authToken: ${{secrets.GITHUB_TOKEN}}
-          context: 'Nextjs Demo App URL on MicroApps'
+          context: 'Nextjs Demo App URL on ${{ matrix.deployName }}'
           description: 'Passed'
           state: 'success'
           sha: ${{github.event.pull_request.head.sha || github.sha}}
@@ -281,7 +281,7 @@ jobs:
         uses: Sibz/github-status-action@v1
         with: 
           authToken: ${{secrets.GITHUB_TOKEN}}
-          context: 'Release App URL on MicroApps'
+          context: 'Release App URL on ${{ matrix.deployName }}'
           description: 'Passed'
           state: 'success'
           sha: ${{github.event.pull_request.head.sha || github.sha}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,16 @@ jobs:
             -s packages/demo-app/static_files \
             -i index.html --overwrite --noCache
 
+      - name: Demo App URL
+        uses: Sibz/github-status-action@v1
+        with: 
+          authToken: ${{secrets.GITHUB_TOKEN}}
+          context: 'Demo App URL on MicroApps'
+          description: 'Passed'
+          state: 'success'
+          sha: ${{github.event.pull_request.head.sha || github.sha}}
+          target_url: https://${EDGE_DOMAIN}${PREFIX}/${DEMO_APP_NAME}/${PACKAGE_VERSION}
+
       - name: Test Demo App
         run: |
           echo Testing App Frame Loading
@@ -230,6 +240,16 @@ jobs:
             -l ${NEXTJS_DEMO_APP_LAMBDA_NAME} \
             -s packages/cdk/node_modules/@pwrdrvr/microapps-app-nextjs-demo-cdk/lib/.static_files/nextjs-demo/${{ needs.build.outputs.nextjsDemoAppPackageVersion }}/ \
             --overwrite --noCache
+
+      - name: Nextjs Demo App URL
+        uses: Sibz/github-status-action@v1
+        with: 
+          authToken: ${{secrets.GITHUB_TOKEN}}
+          context: 'Nextjs Demo App URL on MicroApps'
+          description: 'Passed'
+          state: 'success'
+          sha: ${{github.event.pull_request.head.sha || github.sha}}
+          target_url: https://${EDGE_DOMAIN}${PREFIX}/${NEXTJS_DEMO_APP_NAME}/${{ needs.build.outputs.nextjsDemoAppPackageVersion }}
 
       - name: Test Nextjs Demo App
         run: |
@@ -253,6 +273,16 @@ jobs:
             -l ${RELEASE_APP_LAMBDA_NAME} \
             -s packages/cdk/node_modules/@pwrdrvr/microapps-app-release-cdk/lib/.static_files/release/${{ needs.build.outputs.releaseAppPackageVersion }}/ \
             --overwrite --noCache
+
+      - name: Release App URL
+        uses: Sibz/github-status-action@v1
+        with: 
+          authToken: ${{secrets.GITHUB_TOKEN}}
+          context: 'Release App URL on MicroApps'
+          description: 'Passed'
+          state: 'success'
+          sha: ${{github.event.pull_request.head.sha || github.sha}}
+          target_url: https://${EDGE_DOMAIN}${PREFIX}/${RELEASE_APP_NAME}/${{ needs.build.outputs.releaseAppPackageVersion }}
 
       - name: Test Release App
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
           description: 'Passed'
           state: 'success'
           sha: ${{github.event.pull_request.head.sha || github.sha}}
-          target_url: https://${{ steps.getCDKExports.outputs.edgeDomain }}${{ steps.getCDKExports.outputs.prefix }}/${DEMO_APP_NAME}/${PACKAGE_VERSION}
+          target_url: https://${{ steps.getCDKExports.outputs.edgeDomain }}${{ steps.getCDKExports.outputs.prefix }}/${{ env.DEMO_APP_NAME }}?appver=${{ env.PACKAGE_VERSION }}
 
       - name: Test Demo App
         run: |
@@ -241,7 +241,7 @@ jobs:
             -n ${{ needs.build.outputs.nextjsDemoAppPackageVersion }} \
             -d ${DEPLOYER_LAMBDA_NAME} \
             -l ${NEXTJS_DEMO_APP_LAMBDA_NAME} \
-            -s packages/cdk/node_modules/@pwrdrvr/microapps-app-nextjs-demo-cdk/lib/.static_files/nextjs-demo/${{ needs.build.outputs.nextjsDemoAppPackageVersion }}/ \
+            -s packages/cdk/node_modules/@pwrdrvr/microapps-app-nextjs-demo-cdk/lib/.static_files/${NEXTJS_DEMO_APP_NAME}/${{ needs.build.outputs.nextjsDemoAppPackageVersion }}/ \
             --overwrite --noCache
 
       - name: Nextjs Demo App URL
@@ -252,7 +252,7 @@ jobs:
           description: 'Passed'
           state: 'success'
           sha: ${{github.event.pull_request.head.sha || github.sha}}
-          target_url: https://${{ steps.getCDKExports.outputs.edgeDomain }}${{ steps.getCDKExports.outputs.prefix }}/${NEXTJS_DEMO_APP_NAME}/${{ needs.build.outputs.nextjsDemoAppPackageVersion }}
+          target_url: https://${{ steps.getCDKExports.outputs.edgeDomain }}${{ steps.getCDKExports.outputs.prefix }}/${{ env.NEXTJS_DEMO_APP_NAME }}/${{ needs.build.outputs.nextjsDemoAppPackageVersion }}
 
       - name: Test Nextjs Demo App
         run: |
@@ -274,7 +274,7 @@ jobs:
             -n ${{ needs.build.outputs.releaseAppPackageVersion }} \
             -d ${DEPLOYER_LAMBDA_NAME} \
             -l ${RELEASE_APP_LAMBDA_NAME} \
-            -s packages/cdk/node_modules/@pwrdrvr/microapps-app-release-cdk/lib/.static_files/release/${{ needs.build.outputs.releaseAppPackageVersion }}/ \
+            -s packages/cdk/node_modules/@pwrdrvr/microapps-app-release-cdk/lib/.static_files/${RELEASE_APP_NAME}/${{ needs.build.outputs.releaseAppPackageVersion }}/ \
             --overwrite --noCache
 
       - name: Release App URL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
           description: 'Passed'
           state: 'success'
           sha: ${{github.event.pull_request.head.sha || github.sha}}
-          target_url: https://${EDGE_DOMAIN}${PREFIX}/${DEMO_APP_NAME}/${PACKAGE_VERSION}
+          target_url: https://${{ steps.getCDKExports.outputs.edgeDomain }}${{ steps.getCDKExports.outputs.prefix }}/${DEMO_APP_NAME}/${PACKAGE_VERSION}
 
       - name: Test Demo App
         run: |
@@ -229,7 +229,9 @@ jobs:
           echo Testing App HTML Loading
           curl --fail https://${EDGE_DOMAIN}${PREFIX}/${DEMO_APP_NAME}/${PACKAGE_VERSION}/index.html
           echo Testing App Method Invocation
-          curl --fail https://${EDGE_DOMAIN}${PREFIX}/${DEMO_APP_NAME}/${PACKAGE_VERSION}/someMethod
+          curl --fail "https://${EDGE_DOMAIN}${PREFIX}/${DEMO_APP_NAME}/${PACKAGE_VERSION}/serverIncrement?currValue=1"
+          echo Testing App Method Invocation on _next/data Route
+          curl --fail "https://${EDGE_DOMAIN}${PREFIX}/${DEMO_APP_NAME}/_next/data/${PACKAGE_VERSION}/serverIncrement?currValue=1"
 
       - name: Publish Nextjs Demo App to MicroApps
         run: |
@@ -250,7 +252,7 @@ jobs:
           description: 'Passed'
           state: 'success'
           sha: ${{github.event.pull_request.head.sha || github.sha}}
-          target_url: https://${EDGE_DOMAIN}${PREFIX}/${NEXTJS_DEMO_APP_NAME}/${{ needs.build.outputs.nextjsDemoAppPackageVersion }}
+          target_url: https://${{ steps.getCDKExports.outputs.edgeDomain }}${{ steps.getCDKExports.outputs.prefix }}/${NEXTJS_DEMO_APP_NAME}/${{ needs.build.outputs.nextjsDemoAppPackageVersion }}
 
       - name: Test Nextjs Demo App
         run: |
@@ -283,7 +285,7 @@ jobs:
           description: 'Passed'
           state: 'success'
           sha: ${{github.event.pull_request.head.sha || github.sha}}
-          target_url: https://${EDGE_DOMAIN}${PREFIX}/${RELEASE_APP_NAME}/${{ needs.build.outputs.releaseAppPackageVersion }}
+          target_url: https://${{ steps.getCDKExports.outputs.edgeDomain }}${{ steps.getCDKExports.outputs.prefix }}/${{ env.RELEASE_APP_NAME }}/${{ needs.build.outputs.releaseAppPackageVersion }}
 
       - name: Test Release App
         run: |

--- a/packages/microapps-cdk/src/MicroAppsCF.ts
+++ b/packages/microapps-cdk/src/MicroAppsCF.ts
@@ -339,7 +339,10 @@ export class MicroAppsCF extends Construct implements IMicroAppsCF {
     //
     if (createNextDataPathRoute) {
       distro.addBehavior(
-        posixPath.join(rootPathPrefix, '/*/*/_next/data/*'),
+        // Note: send anything with _next/data after the appName (and optional version)
+        // to the app origin as iframe-less will have no version before _next/data
+        // in the path
+        posixPath.join(rootPathPrefix, '/*/_next/data/*'),
         apiGwyOrigin,
         apiGwyBehaviorOptions,
       );

--- a/packages/microapps-edge-to-origin/src/index.route.spec.ts
+++ b/packages/microapps-edge-to-origin/src/index.route.spec.ts
@@ -386,11 +386,113 @@ describe('edge-to-origin - routing - without prefix', () => {
     expect(requestResponse.headers.host).toHaveLength(1);
     expect(requestResponse.headers.host[0].key).toBe('Host');
     expect(requestResponse.headers.host[0].value).toBe('abc1234567.lambda-url.us-east-1.on.aws');
+    expect(requestResponse.uri).toBe('/batdirect/_next/data/1.2.2-beta.1/abc123.json');
     expect(requestResponse).toHaveProperty('origin');
     expect(requestResponse.origin).toHaveProperty('custom');
     expect(requestResponse?.origin?.custom).toHaveProperty('domainName');
     expect(requestResponse?.origin?.custom?.domainName).toBe(
       'abc1234567.lambda-url.us-east-1.on.aws',
+    );
+  });
+
+  it('should route `iframe` _next/data request with appName and version to origin', async () => {
+    theConfig.replaceHostHeader = true;
+
+    const app = new Application({
+      AppName: 'BatIframe',
+      DisplayName: 'Iframe Bat App',
+    });
+    await app.Save(dbManager);
+
+    const versionDefault = new Version({
+      AppName: 'BatIframe',
+      SemVer: '1.2.1-beta.1',
+      Status: 'deployed',
+      Type: 'lambda-url',
+      StartupType: 'iframe',
+      URL: 'https://abc123.lambda-url.us-east-1.on.aws/',
+    });
+    await versionDefault.Save(dbManager);
+    const versionNonDefault = new Version({
+      AppName: 'BatIframe',
+      SemVer: '1.2.3',
+      Status: 'deployed',
+      Type: 'lambda-url',
+      StartupType: 'iframe',
+      URL: 'https://abc123456.lambda-url.us-east-1.on.aws/',
+    });
+    await versionNonDefault.Save(dbManager);
+
+    const rules = new Rules({
+      AppName: 'BatIframe',
+      Version: 0,
+      RuleSet: { default: { SemVer: '1.2.1-beta.1', AttributeName: '', AttributeValue: '' } },
+    });
+    await rules.Save(dbManager);
+
+    // Call the handler
+    // @ts-expect-error no callback
+    const response = await handler(
+      {
+        Records: [
+          {
+            cf: {
+              config: {
+                distributionDomainName: 'zyz.cloudfront.net',
+                distributionId: '123',
+                eventType: 'origin-request',
+                requestId: '123',
+              },
+              request: {
+                headers: {
+                  host: [
+                    {
+                      key: 'Host',
+                      value: 'zyz.cloudfront.net',
+                    },
+                  ],
+                },
+                method: 'GET',
+                querystring: '',
+                clientIp: '1.1.1.1',
+                uri: '/batiframe/1.2.3/_next/data/3n-GzDjz4nifw5OnywVdV/posts/ssg-ssr.json',
+                origin: {
+                  custom: {
+                    customHeaders: {},
+                    domainName: 'zyz.cloudfront.net',
+                    keepaliveTimeout: 5,
+                    path: '',
+                    port: 443,
+                    protocol: 'https',
+                    readTimeout: 30,
+                    sslProtocols: ['TLSv1.2'],
+                  },
+                },
+              },
+            },
+          },
+        ],
+      } as lambda.CloudFrontRequestEvent,
+      {} as lambda.Context,
+    );
+
+    const requestResponse = response as lambda.CloudFrontRequest;
+    expect(requestResponse).toBeDefined();
+    expect(requestResponse).not.toHaveProperty('status');
+    expect(requestResponse).not.toHaveProperty('body');
+    expect(requestResponse).toHaveProperty('headers');
+    expect(requestResponse.headers).toHaveProperty('host');
+    expect(requestResponse.headers.host).toHaveLength(1);
+    expect(requestResponse.headers.host[0].key).toBe('Host');
+    expect(requestResponse.headers.host[0].value).toBe('abc123456.lambda-url.us-east-1.on.aws');
+    expect(requestResponse.uri).toBe(
+      '/batiframe/1.2.3/_next/data/3n-GzDjz4nifw5OnywVdV/posts/ssg-ssr.json',
+    );
+    expect(requestResponse).toHaveProperty('origin');
+    expect(requestResponse.origin).toHaveProperty('custom');
+    expect(requestResponse?.origin?.custom).toHaveProperty('domainName');
+    expect(requestResponse?.origin?.custom?.domainName).toBe(
+      'abc123456.lambda-url.us-east-1.on.aws',
     );
   });
 

--- a/packages/microapps-edge-to-origin/src/index.route.spec.ts
+++ b/packages/microapps-edge-to-origin/src/index.route.spec.ts
@@ -291,6 +291,190 @@ describe('edge-to-origin - routing - without prefix', () => {
     expect(requestResponse?.origin?.custom?.domainName).toBe('abc123.lambda-url.us-east-1.on.aws');
   });
 
+  it('should route `direct` _next/data request with appName and version to origin', async () => {
+    theConfig.replaceHostHeader = true;
+
+    const app = new Application({
+      AppName: 'BatDirect',
+      DisplayName: 'Direct Bat App',
+    });
+    await app.Save(dbManager);
+
+    {
+      const version = new Version({
+        AppName: 'BatDirect',
+        SemVer: '1.2.1-beta.1',
+        Status: 'deployed',
+        Type: 'lambda-url',
+        StartupType: 'direct',
+        URL: 'https://abc123.lambda-url.us-east-1.on.aws/',
+      });
+      await version.Save(dbManager);
+    }
+
+    {
+      const version = new Version({
+        AppName: 'BatDirect',
+        SemVer: '1.2.2-beta.1',
+        Status: 'deployed',
+        Type: 'lambda-url',
+        StartupType: 'direct',
+        URL: 'https://abc1234567.lambda-url.us-east-1.on.aws/',
+      });
+      await version.Save(dbManager);
+    }
+
+    const rules = new Rules({
+      AppName: 'BatDirect',
+      Version: 0,
+      RuleSet: { default: { SemVer: '1.2.1-beta.1', AttributeName: '', AttributeValue: '' } },
+    });
+    await rules.Save(dbManager);
+
+    // Call the handler
+    // @ts-expect-error no callback
+    const response = await handler(
+      {
+        Records: [
+          {
+            cf: {
+              config: {
+                distributionDomainName: 'zyz.cloudfront.net',
+                distributionId: '123',
+                eventType: 'origin-request',
+                requestId: '123',
+              },
+              request: {
+                headers: {
+                  host: [
+                    {
+                      key: 'Host',
+                      value: 'zyz.cloudfront.net',
+                    },
+                  ],
+                },
+                method: 'GET',
+                querystring: '',
+                clientIp: '1.1.1.1',
+                uri: '/batdirect/_next/data/1.2.2-beta.1/abc123.json',
+                origin: {
+                  custom: {
+                    customHeaders: {},
+                    domainName: 'zyz.cloudfront.net',
+                    keepaliveTimeout: 5,
+                    path: '',
+                    port: 443,
+                    protocol: 'https',
+                    readTimeout: 30,
+                    sslProtocols: ['TLSv1.2'],
+                  },
+                },
+              },
+            },
+          },
+        ],
+      } as lambda.CloudFrontRequestEvent,
+      {} as lambda.Context,
+    );
+
+    const requestResponse = response as lambda.CloudFrontRequest;
+    expect(requestResponse).toBeDefined();
+    expect(requestResponse).not.toHaveProperty('status');
+    expect(requestResponse).not.toHaveProperty('body');
+    expect(requestResponse).toHaveProperty('headers');
+    expect(requestResponse.headers).toHaveProperty('host');
+    expect(requestResponse.headers.host).toHaveLength(1);
+    expect(requestResponse.headers.host[0].key).toBe('Host');
+    expect(requestResponse.headers.host[0].value).toBe('abc1234567.lambda-url.us-east-1.on.aws');
+    expect(requestResponse).toHaveProperty('origin');
+    expect(requestResponse.origin).toHaveProperty('custom');
+    expect(requestResponse?.origin?.custom).toHaveProperty('domainName');
+    expect(requestResponse?.origin?.custom?.domainName).toBe(
+      'abc1234567.lambda-url.us-east-1.on.aws',
+    );
+  });
+
+  // 404ing a "missing version" is kinda tricky and it means that the 2nd folder
+  // can't look like a version or we'll always 404 it rather than passing it through.
+  it.skip('should 404 `direct` _next/data request with appName and version to origin', async () => {
+    theConfig.replaceHostHeader = true;
+
+    const app = new Application({
+      AppName: 'BatDirect',
+      DisplayName: 'Direct Bat App',
+    });
+    await app.Save(dbManager);
+
+    const version = new Version({
+      AppName: 'BatDirect',
+      SemVer: '1.2.1-beta.1',
+      Status: 'deployed',
+      Type: 'lambda-url',
+      StartupType: 'direct',
+      URL: 'https://abc123.lambda-url.us-east-1.on.aws/',
+    });
+    await version.Save(dbManager);
+
+    const rules = new Rules({
+      AppName: 'BatDirect',
+      Version: 0,
+      RuleSet: { default: { SemVer: '1.2.1-beta.1', AttributeName: '', AttributeValue: '' } },
+    });
+    await rules.Save(dbManager);
+
+    // Call the handler
+    // @ts-expect-error no callback
+    const response = await handler(
+      {
+        Records: [
+          {
+            cf: {
+              config: {
+                distributionDomainName: 'zyz.cloudfront.net',
+                distributionId: '123',
+                eventType: 'origin-request',
+                requestId: '123',
+              },
+              request: {
+                headers: {
+                  host: [
+                    {
+                      key: 'Host',
+                      value: 'zyz.cloudfront.net',
+                    },
+                  ],
+                },
+                method: 'GET',
+                querystring: '',
+                clientIp: '1.1.1.1',
+                uri: '/batdirect/_next/data/1.2.2-beta.1/abc123.json',
+                origin: {
+                  custom: {
+                    customHeaders: {},
+                    domainName: 'zyz.cloudfront.net',
+                    keepaliveTimeout: 5,
+                    path: '',
+                    port: 443,
+                    protocol: 'https',
+                    readTimeout: 30,
+                    sslProtocols: ['TLSv1.2'],
+                  },
+                },
+              },
+            },
+          },
+        ],
+      } as lambda.CloudFrontRequestEvent,
+      {} as lambda.Context,
+    );
+
+    const responseResponse = response as lambda.CloudFrontResultResponse;
+    expect(responseResponse).toBeDefined();
+    expect(responseResponse).toHaveProperty('status');
+    expect(responseResponse?.status).toBe('404');
+    expect(responseResponse).not.toHaveProperty('body');
+  });
+
   it('should route `iframe` app request with appName by creating iframe response for ?appver=[version]', async () => {
     theConfig.replaceHostHeader = true;
 

--- a/packages/microapps-edge-to-origin/src/index.route.spec.ts
+++ b/packages/microapps-edge-to-origin/src/index.route.spec.ts
@@ -498,7 +498,7 @@ describe('edge-to-origin - routing - without prefix', () => {
 
   // 404ing a "missing version" is kinda tricky and it means that the 2nd folder
   // can't look like a version or we'll always 404 it rather than passing it through.
-  it.skip('should 404 `direct` _next/data request with appName and version to origin', async () => {
+  it.skip('should 404 `direct` _next/data request with appName and version', async () => {
     theConfig.replaceHostHeader = true;
 
     const app = new Application({
@@ -550,6 +550,85 @@ describe('edge-to-origin - routing - without prefix', () => {
                 querystring: '',
                 clientIp: '1.1.1.1',
                 uri: '/batdirect/_next/data/1.2.2-beta.1/abc123.json',
+                origin: {
+                  custom: {
+                    customHeaders: {},
+                    domainName: 'zyz.cloudfront.net',
+                    keepaliveTimeout: 5,
+                    path: '',
+                    port: 443,
+                    protocol: 'https',
+                    readTimeout: 30,
+                    sslProtocols: ['TLSv1.2'],
+                  },
+                },
+              },
+            },
+          },
+        ],
+      } as lambda.CloudFrontRequestEvent,
+      {} as lambda.Context,
+    );
+
+    const responseResponse = response as lambda.CloudFrontResultResponse;
+    expect(responseResponse).toBeDefined();
+    expect(responseResponse).toHaveProperty('status');
+    expect(responseResponse?.status).toBe('404');
+    expect(responseResponse).not.toHaveProperty('body');
+  });
+
+  it('should 404 `direct` request with appName and ?appver=', async () => {
+    theConfig.replaceHostHeader = true;
+
+    const app = new Application({
+      AppName: 'BatDirect',
+      DisplayName: 'Direct Bat App',
+    });
+    await app.Save(dbManager);
+
+    const version = new Version({
+      AppName: 'BatDirect',
+      SemVer: '1.2.1-beta.1',
+      Status: 'deployed',
+      Type: 'lambda-url',
+      StartupType: 'direct',
+      URL: 'https://abc123.lambda-url.us-east-1.on.aws/',
+    });
+    await version.Save(dbManager);
+
+    const rules = new Rules({
+      AppName: 'BatDirect',
+      Version: 0,
+      RuleSet: { default: { SemVer: '1.2.1-beta.1', AttributeName: '', AttributeValue: '' } },
+    });
+    await rules.Save(dbManager);
+
+    // Call the handler
+    // @ts-expect-error no callback
+    const response = await handler(
+      {
+        Records: [
+          {
+            cf: {
+              config: {
+                distributionDomainName: 'zyz.cloudfront.net',
+                distributionId: '123',
+                eventType: 'origin-request',
+                requestId: '123',
+              },
+              request: {
+                headers: {
+                  host: [
+                    {
+                      key: 'Host',
+                      value: 'zyz.cloudfront.net',
+                    },
+                  ],
+                },
+                method: 'GET',
+                querystring: '',
+                clientIp: '1.1.1.1',
+                uri: '/batdirect?appver=1.2.2-beta.1',
                 origin: {
                   custom: {
                     customHeaders: {},

--- a/packages/microapps-edge-to-origin/src/index.ts
+++ b/packages/microapps-edge-to-origin/src/index.ts
@@ -127,6 +127,13 @@ export const handler: lambda.CloudFrontRequestHandler = async (
         };
       }
 
+      if (route.statusCode && route.statusCode !== 200) {
+        return {
+          status: `${route.statusCode}`,
+          statusDescription: route.errorMessage,
+        };
+      }
+
       // Fall through to apigwy handling if type is not url
       if (route.url && (route.type === 'url' || route.type === 'lambda-url')) {
         log.info('rewriting to url', { url: route.url });

--- a/packages/microapps-edge-to-origin/src/index.ts
+++ b/packages/microapps-edge-to-origin/src/index.ts
@@ -199,6 +199,8 @@ export const handler: lambda.CloudFrontRequestHandler = async (
     if (request.origin?.custom?.domainName) {
       request.origin = { ...request.origin };
       request.origin.custom.domainName = originHost;
+
+      // Remove the appver query string to avoid problems with some frameworks
       request.querystring = (request.querystring ?? '').replace(/&?appver=[^&]*/, '');
     }
 

--- a/packages/microapps-router-lib/src/index.ts
+++ b/packages/microapps-router-lib/src/index.ts
@@ -186,6 +186,14 @@ export async function GetRoute(event: IGetRouteEvent): Promise<IGetRouteResult> 
       }
     }
 
+    // Check for a version in the path
+    // Examples
+    //  / appName / semVer / somepath
+    //  / appName / _next / data / semVer / somepath
+    const possibleSemVerPathNextData = parts.length >= 5 ? parts[4] : '';
+    const possibleSemVerPathAfterApp = parts.length >= 3 ? parts[2] : '';
+    const possibleSemVerPath = possibleSemVerPathNextData || possibleSemVerPathAfterApp;
+
     //  / appName (/ something)?
     // ^  ^^^^^^^    ^^^^^^^^^
     // 0        1            2
@@ -195,7 +203,7 @@ export async function GetRoute(event: IGetRouteEvent): Promise<IGetRouteResult> 
       normalizedPathPrefix,
       event,
       appName: parts[1],
-      possibleSemVerPath: parts.length >= 3 ? parts[2] : '',
+      possibleSemVerPath,
       possibleSemVerQuery: queryStringParameters?.get('appver') || '',
       additionalParts,
     });

--- a/packages/microapps-router-lib/src/index.ts
+++ b/packages/microapps-router-lib/src/index.ts
@@ -312,6 +312,17 @@ async function RouteApp(opts: {
     // We got a version for the query string, but it's not in the path,
     // so fall back to normal routing (create an iframe or direct route)
     versionInfoToUse = possibleSemVerQueryVersionInfo;
+  } else if (possibleSemVerQuery) {
+    // We got a version in the query string but it does not exist
+    // This needs to 404 as this is a very specific request for a specific version
+    log.error(`could not find app ${appName}, for path ${event.rawPath} - returning 404`, {
+      statusCode: 404,
+    });
+
+    return {
+      statusCode: 404,
+      errorMessage: `Router - Could not find app: ${event.rawPath}, ${appName}`,
+    };
   } else {
     //
     // TODO: Get the incoming attributes of user


### PR DESCRIPTION
- Add statuses with app URLs to Pull Requests
- Route `/[appname]/_next/data/[semver]/something` requests in the Edge lambda to the correct app
- 404 `?appver=` requests that point to a version that does not exist
- Fixes #263 