### PR TITLE
Update release app to iframe-less

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,8 +114,10 @@ jobs:
         run: |
           if [ "${{ matrix.deployName }}" == "microapps-basic-prefix" ]; then
             echo 'PREFIX=/prefix' >> $GITHUB_ENV
+            echo 'PREFIX_U=/u002Fprefix' >> $GITHUB_ENV
           else
             echo 'PREFIX=' >> $GITHUB_ENV
+            echo 'PREFIX_U=' >> $GITHUB_ENV
           fi
 
       - name: Use Node.js 16
@@ -149,12 +151,14 @@ jobs:
         run: |
           if [ -n "${PREFIX}" ] ; then
             npx replace-in-file "/\/${NEXTJS_DEMO_APP_NAME}/g" ${PREFIX}/${NEXTJS_DEMO_APP_NAME} --configFile=.nextjs-demo-replace.config.js --isRegex
+            npx replace-in-file "/\/u002F${NEXTJS_DEMO_APP_NAME}/g" ${PREFIX_U}/u002F${NEXTJS_DEMO_APP_NAME} --configFile=.release-replace.config.js --isRegex
           fi
 
       - name: Stitch Prefix into Release App
         run: |
           if [ -n "${PREFIX}" ] ; then
             npx replace-in-file "/\/${RELEASE_APP_NAME}/g" ${PREFIX}/${RELEASE_APP_NAME} --configFile=.release-replace.config.js --isRegex
+            npx replace-in-file "/\/u002F${RELEASE_APP_NAME}/g" ${PREFIX_U}/u002F${RELEASE_APP_NAME} --configFile=.release-replace.config.js --isRegex
           fi
 
       - name: Synth CDK Stack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,7 +318,7 @@ jobs:
         run: |
           npx microapps-publish publish \
             -t lambda-url \
-            --startup-type iframe \
+            --startup-type direct \
             -a ${RELEASE_APP_NAME} \
             -n ${{ needs.build.outputs.releaseAppPackageVersion }} \
             -d ${DEPLOYER_LAMBDA_NAME} \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # Workflow references:
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
 # https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-name: Build / Deploy - CI
+name: CI
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,9 +309,7 @@ jobs:
           sha: ${{github.event.pull_request.head.sha || github.sha}}
           target_url: https://${{ steps.getCDKExports.outputs.edgeDomain }}${{ steps.getCDKExports.outputs.prefix }}/${{ env.NEXTJS_DEMO_APP_NAME }}/${{ needs.build.outputs.nextjsDemoAppPackageVersion }}
 
-      # TODO: Unskip the following tests once the Nextjs Demo App is fixed for prefix deploys
       - name: Test Nextjs Demo App
-        if: matrix.deployName != 'microapps-basic-prefix'
         run: |
           echo Testing App Page Loading
           curl -H"accept: text/html" --fail https://${EDGE_DOMAIN}${PREFIX}/${NEXTJS_DEMO_APP_NAME}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,8 @@ jobs:
 
       - name: Publish Demo App to MicroApps
         run: |
-          npx microapps-publish publish -a ${DEMO_APP_NAME} \
+          npx microapps-publish publish \
+            -a ${DEMO_APP_NAME} \
             -t lambda-url \
             --startup-type direct \
             -n ${PACKAGE_VERSION} \
@@ -235,7 +236,8 @@ jobs:
 
       - name: Publish Demo App to MicroApps - To Delete
         run: |
-          npx microapps-publish publish -a ${DEMO_APP_NAME} \
+          npx microapps-publish publish \
+            -a ${DEMO_APP_NAME} \
             -t lambda-url \
             --startup-type direct \
             -n 0.0.0-test.1 \
@@ -252,7 +254,8 @@ jobs:
 
       - name: Publish Demo App to MicroApps - Root App
         run: |
-          npx microapps-publish publish -a '[root]' \
+          npx microapps-publish publish \
+            -a '[root]' \
             -t lambda-url \
             --startup-type direct \
             -n ${PACKAGE_VERSION} \
@@ -286,6 +289,7 @@ jobs:
         run: |
           npx microapps-publish publish \
             -t lambda-url \
+            --startup-type direct \
             -a ${NEXTJS_DEMO_APP_NAME} \
             -n ${{ needs.build.outputs.nextjsDemoAppPackageVersion }} \
             -d ${DEPLOYER_LAMBDA_NAME} \
@@ -305,14 +309,12 @@ jobs:
 
       - name: Test Nextjs Demo App
         run: |
-          echo Testing App Frame Loading
+          echo Testing App Page Loading
           curl -H"accept: text/html" --fail https://${EDGE_DOMAIN}${PREFIX}/${NEXTJS_DEMO_APP_NAME}/
           echo Testing App HTML Loading
-          curl -H"accept: text/html" --fail https://${EDGE_DOMAIN}${PREFIX}/${NEXTJS_DEMO_APP_NAME}/${{ needs.build.outputs.nextjsDemoAppPackageVersion }}
+          curl -H"accept: text/html" --fail https://${EDGE_DOMAIN}${PREFIX}/${NEXTJS_DEMO_APP_NAME}?appver=${{ needs.build.outputs.nextjsDemoAppPackageVersion }}
           echo Testing Post Page Loading
-          curl -H"accept: text/html" --fail https://${EDGE_DOMAIN}${PREFIX}/${NEXTJS_DEMO_APP_NAME}/${{ needs.build.outputs.nextjsDemoAppPackageVersion }}/posts/pre-rendering
-          echo Testing Image Rendering
-          curl -H"accept: image/jpg" --fail -o /dev/null https://${EDGE_DOMAIN}${PREFIX}/${NEXTJS_DEMO_APP_NAME}/${{ needs.build.outputs.nextjsDemoAppPackageVersion }}/_next/image?url=%2Fimages%2Fprofile.jpg&w=384&q=75
+          curl -H"accept: text/html" --fail https://${EDGE_DOMAIN}${PREFIX}/${NEXTJS_DEMO_APP_NAME}/posts/pre-rendering?appver=${{ needs.build.outputs.nextjsDemoAppPackageVersion }}
 
       - name: Publish Release App to MicroApps
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,7 +310,7 @@ jobs:
       - name: Test Nextjs Demo App
         run: |
           echo Testing App Page Loading
-          curl -H"accept: text/html" --fail https://${EDGE_DOMAIN}${PREFIX}/${NEXTJS_DEMO_APP_NAME}/
+          curl -H"accept: text/html" --fail https://${EDGE_DOMAIN}${PREFIX}/${NEXTJS_DEMO_APP_NAME}
           echo Testing App HTML Loading
           curl -H"accept: text/html" --fail https://${EDGE_DOMAIN}${PREFIX}/${NEXTJS_DEMO_APP_NAME}?appver=${{ needs.build.outputs.nextjsDemoAppPackageVersion }}
           echo Testing Post Page Loading
@@ -341,9 +341,9 @@ jobs:
       - name: Test Release App
         run: |
           echo Testing App Frame Loading
-          curl -H"accept: text/html" --fail https://${EDGE_DOMAIN}${PREFIX}/${RELEASE_APP_NAME}/
+          curl -H"accept: text/html" --fail https://${EDGE_DOMAIN}${PREFIX}/${RELEASE_APP_NAME}
           echo Testing App HTML Loading
-          curl -H"accept: text/html" --fail https://${EDGE_DOMAIN}${PREFIX}/${RELEASE_APP_NAME}/?appver=${{ needs.build.outputs.releaseAppPackageVersion }}
+          curl -H"accept: text/html" --fail https://${EDGE_DOMAIN}${PREFIX}/${RELEASE_APP_NAME}?appver=${{ needs.build.outputs.releaseAppPackageVersion }}
           echo Testing App Method Invocation
           curl -H"accept: application/json" --fail https://${EDGE_DOMAIN}${PREFIX}/${RELEASE_APP_NAME}/${{ needs.build.outputs.releaseAppPackageVersion }}/api/refresh/${DEMO_APP_NAME}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
         run: |
           if [ -n "${PREFIX}" ] ; then
             npx replace-in-file "/\/${NEXTJS_DEMO_APP_NAME}/g" ${PREFIX}/${NEXTJS_DEMO_APP_NAME} --configFile=.nextjs-demo-replace.config.js --isRegex
-            npx replace-in-file "/\/u002F${NEXTJS_DEMO_APP_NAME}/g" ${PREFIX_U}/u002F${NEXTJS_DEMO_APP_NAME} --configFile=.release-replace.config.js --isRegex
+            npx replace-in-file "/\/u002F${NEXTJS_DEMO_APP_NAME}/g" ${PREFIX_U}/u002F${NEXTJS_DEMO_APP_NAME} --configFile=.nextjs-demo-replace.config.js --isRegex
           fi
 
       - name: Stitch Prefix into Release App

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,14 +149,12 @@ jobs:
         run: |
           if [ -n "${PREFIX}" ] ; then
             npx replace-in-file "/\/${NEXTJS_DEMO_APP_NAME}/g" ${PREFIX}/${NEXTJS_DEMO_APP_NAME} --configFile=.nextjs-demo-replace.config.js --isRegex
-            npx replace-in-file "/\/${NEXTJS_DEMO_APP_NAME}\/${{ needs.build.outputs.nextjsDemoAppPackageVersion }}/g" /${NEXTJS_DEMO_APP_NAME}/${{ needs.build.outputs.nextjsDemoAppPackageVersion }} --configFile=.nextjs-demo-replace.config.js --isRegex
           fi
 
       - name: Stitch Prefix into Release App
         run: |
           if [ -n "${PREFIX}" ] ; then
             npx replace-in-file "/\/${RELEASE_APP_NAME}/g" ${PREFIX}/${RELEASE_APP_NAME} --configFile=.release-replace.config.js --isRegex
-            npx replace-in-file "/\/${RELEASE_APP_NAME}\/${{ needs.build.outputs.releaseAppPackageVersion }}/g" /${RELEASE_APP_NAME}/${{ needs.build.outputs.releaseAppPackageVersion }} --configFile=.release-replace.config.js --isRegex
           fi
 
       - name: Synth CDK Stack
@@ -307,7 +305,9 @@ jobs:
           sha: ${{github.event.pull_request.head.sha || github.sha}}
           target_url: https://${{ steps.getCDKExports.outputs.edgeDomain }}${{ steps.getCDKExports.outputs.prefix }}/${{ env.NEXTJS_DEMO_APP_NAME }}/${{ needs.build.outputs.nextjsDemoAppPackageVersion }}
 
+      # TODO: Unskip the following tests once the Nextjs Demo App is fixed for prefix deploys
       - name: Test Nextjs Demo App
+        if: matrix.deployName != 'microapps-basic-prefix'
         run: |
           echo Testing App Page Loading
           curl -H"accept: text/html" --fail https://${EDGE_DOMAIN}${PREFIX}/${NEXTJS_DEMO_APP_NAME}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,7 +290,7 @@ jobs:
             -n ${{ needs.build.outputs.nextjsDemoAppPackageVersion }} \
             -d ${DEPLOYER_LAMBDA_NAME} \
             -l ${NEXTJS_DEMO_APP_LAMBDA_NAME} \
-            -s packages/cdk/node_modules/@pwrdrvr/microapps-app-nextjs-demo-cdk/lib/.static_files/${NEXTJS_DEMO_APP_NAME}/${{ needs.build.outputs.nextjsDemoAppPackageVersion }}/ \
+            -s packages/cdk/node_modules/@pwrdrvr/microapps-app-nextjs-demo-cdk/lib/microapps-app-nextjs-demo/.static_files/ \
             --overwrite --noCache
 
       - name: Nextjs Demo App URL
@@ -323,7 +323,7 @@ jobs:
             -n ${{ needs.build.outputs.releaseAppPackageVersion }} \
             -d ${DEPLOYER_LAMBDA_NAME} \
             -l ${RELEASE_APP_LAMBDA_NAME} \
-            -s packages/cdk/node_modules/@pwrdrvr/microapps-app-release-cdk/lib/.static_files/${RELEASE_APP_NAME}/${{ needs.build.outputs.releaseAppPackageVersion }}/ \
+            -s packages/cdk/node_modules/@pwrdrvr/microapps-app-release-cdk/lib/microapps-app-release/.static_files/ \
             --overwrite --noCache
 
       - name: Release App URL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,7 +343,7 @@ jobs:
           echo Testing App Frame Loading
           curl -H"accept: text/html" --fail https://${EDGE_DOMAIN}${PREFIX}/${RELEASE_APP_NAME}/
           echo Testing App HTML Loading
-          curl -H"accept: text/html" --fail https://${EDGE_DOMAIN}${PREFIX}/${RELEASE_APP_NAME}/${{ needs.build.outputs.releaseAppPackageVersion }}
+          curl -H"accept: text/html" --fail https://${EDGE_DOMAIN}${PREFIX}/${RELEASE_APP_NAME}/?appver=${{ needs.build.outputs.releaseAppPackageVersion }}
           echo Testing App Method Invocation
           curl -H"accept: application/json" --fail https://${EDGE_DOMAIN}${PREFIX}/${RELEASE_APP_NAME}/${{ needs.build.outputs.releaseAppPackageVersion }}/api/refresh/${DEMO_APP_NAME}
 

--- a/.nextjs-demo-replace.config.js
+++ b/.nextjs-demo-replace.config.js
@@ -1,4 +1,4 @@
 // https://www.npmjs.com/package/replace-in-file
 module.exports = {
-  files: 'packages/cdk/node_modules/@pwrdrvr/microapps-app-nextjs-demo-cdk/lib/.serverless_nextjs/**/*,packages/cdk/node_modules/@pwrdrvr/microapps-app-nextjs-demo-cdk/lib/.static_files/**/*',
+  files: 'packages/cdk/node_modules/@pwrdrvr/microapps-app-nextjs-demo-cdk/lib/microapps-app-nextjs-demo/.next/**/*,packages/cdk/node_modules/@pwrdrvr/microapps-app-nextjs-demo-cdk/lib/microapps-app-nextjs-demo/.serverless_nextjs/**/*,packages/cdk/node_modules/@pwrdrvr/microapps-app-nextjs-demo-cdk/lib/microapps-app-nextjs-demo/.static_files/**/*',
 };

--- a/.nextjs-demo-replace.config.js
+++ b/.nextjs-demo-replace.config.js
@@ -1,4 +1,4 @@
 // https://www.npmjs.com/package/replace-in-file
 module.exports = {
-  files: 'packages/cdk/node_modules/@pwrdrvr/microapps-app-nextjs-demo-cdk/lib/microapps-app-nextjs-demo/.next/**/*,packages/cdk/node_modules/@pwrdrvr/microapps-app-nextjs-demo-cdk/lib/microapps-app-nextjs-demo/.serverless_nextjs/**/*,packages/cdk/node_modules/@pwrdrvr/microapps-app-nextjs-demo-cdk/lib/microapps-app-nextjs-demo/.static_files/**/*',
+  files: 'packages/cdk/node_modules/@pwrdrvr/microapps-app-nextjs-demo-cdk/lib/microapps-app-nextjs-demo/.next/**/*,packages/cdk/node_modules/@pwrdrvr/microapps-app-nextjs-demo-cdk/lib/microapps-app-nextjs-demo/next.config.js,packages/cdk/node_modules/@pwrdrvr/microapps-app-nextjs-demo-cdk/lib/microapps-app-nextjs-demo/.static_files/**/*',
 };

--- a/.release-replace.config.js
+++ b/.release-replace.config.js
@@ -1,4 +1,4 @@
 // https://www.npmjs.com/package/replace-in-file
 module.exports = {
-  files: 'packages/cdk/node_modules/@pwrdrvr/microapps-app-release-cdk/lib/microapps-app-release/.next/**/*,packages/cdk/node_modules/@pwrdrvr/microapps-app-release-cdk/lib/microapps-app-release/.serverless_nextjs/**/*,packages/cdk/node_modules/@pwrdrvr/microapps-app-release-cdk/lib/microapps-app-release/.static_files/**/*',
+  files: 'packages/cdk/node_modules/@pwrdrvr/microapps-app-release-cdk/lib/microapps-app-release/**/*',
 };

--- a/.release-replace.config.js
+++ b/.release-replace.config.js
@@ -1,4 +1,4 @@
 // https://www.npmjs.com/package/replace-in-file
 module.exports = {
-  files: 'packages/cdk/node_modules/@pwrdrvr/microapps-app-release-cdk/lib/.serverless_nextjs/**/*,packages/cdk/node_modules/@pwrdrvr/microapps-app-release-cdk/lib/.static_files/**/*',
+  files: 'packages/cdk/node_modules/@pwrdrvr/microapps-app-release-cdk/lib/microapps-app-release/.next/**/*,packages/cdk/node_modules/@pwrdrvr/microapps-app-release-cdk/lib/microapps-app-release/.serverless_nextjs/**/*,packages/cdk/node_modules/@pwrdrvr/microapps-app-release-cdk/lib/microapps-app-release/.static_files/**/*',
 };

--- a/.release-replace.config.js
+++ b/.release-replace.config.js
@@ -1,4 +1,4 @@
 // https://www.npmjs.com/package/replace-in-file
 module.exports = {
-  files: 'packages/cdk/node_modules/@pwrdrvr/microapps-app-release-cdk/lib/microapps-app-release/**/*',
+  files: 'packages/cdk/node_modules/@pwrdrvr/microapps-app-release-cdk/lib/microapps-app-release/.next/**/*,packages/cdk/node_modules/@pwrdrvr/microapps-app-release-cdk/lib/microapps-app-release/next.config.js,packages/cdk/node_modules/@pwrdrvr/microapps-app-release-cdk/lib/microapps-app-release/.static_files/**/*',
 };

--- a/packages/cdk/lib/MicroApps.ts
+++ b/packages/cdk/lib/MicroApps.ts
@@ -269,10 +269,8 @@ export class MicroAppsStack extends Stack {
       const app = new MicroAppsAppRelease(this, 'release-app', {
         functionName: assetNameRoot ? `${assetNameRoot}-app-release${assetNameSuffix}` : undefined,
         table: microapps.svcs.table,
-        staticAssetsS3Bucket: microapps.s3.bucketApps,
         nodeEnv,
         removalPolicy,
-        sharpLayer,
       });
 
       new CfnOutput(this, 'release-app-func-name', {
@@ -286,10 +284,8 @@ export class MicroAppsStack extends Stack {
         functionName: assetNameRoot
           ? `${assetNameRoot}-app-nextjs-demo${assetNameSuffix}`
           : undefined,
-        staticAssetsS3Bucket: microapps.s3.bucketApps,
         nodeEnv,
         removalPolicy,
-        sharpLayer,
       });
 
       new CfnOutput(this, 'nextjs-demo-app-func-name', {

--- a/packages/cdk/lib/MicroApps.ts
+++ b/packages/cdk/lib/MicroApps.ts
@@ -227,6 +227,7 @@ export class MicroAppsStack extends Stack {
     // the 2nd generation routing that needs the table name
     // in the edge lambda function
     const table = new MicroAppsTable(this, 'microapps-table', {
+      removalPolicy,
       ...(tableName ? { assetNameRoot: tableName } : optionalAssetNameOpts),
     });
 
@@ -254,15 +255,6 @@ export class MicroAppsStack extends Stack {
         value: `${demoApp.lambdaFunction.functionName}`,
         exportName: `${this.stackName}-demo-app-func-name`,
       });
-    }
-
-    let sharpLayer: lambda.ILayerVersion | undefined = undefined;
-    if (deployReleaseApp || deployNextjsDemoApp) {
-      sharpLayer = lambda.LayerVersion.fromLayerVersionArn(
-        this,
-        'sharp-lambda-layer',
-        `arn:aws:lambda:${Aws.REGION}:${Aws.ACCOUNT_ID}:layer:sharp-heic:1`,
-      );
     }
 
     if (deployReleaseApp) {

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -14,8 +14,8 @@
     "cdk": "cdk"
   },
   "dependencies": {
-    "@pwrdrvr/microapps-app-nextjs-demo-cdk": "^0.2.1",
-    "@pwrdrvr/microapps-app-release-cdk": "^0.2.2",
+    "@pwrdrvr/microapps-app-nextjs-demo-cdk": "^0.3.1",
+    "@pwrdrvr/microapps-app-release-cdk": "^0.4.0",
     "source-map-support": "^0.5.16"
   },
   "devDependencies": {

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@pwrdrvr/microapps-app-nextjs-demo-cdk": "^0.3.1",
-    "@pwrdrvr/microapps-app-release-cdk": "^0.4.0",
+    "@pwrdrvr/microapps-app-release-cdk": "^0.4.2",
     "source-map-support": "^0.5.16"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2328,18 +2328,18 @@
   resolved "https://registry.yarnpkg.com/@oozcitak/util/-/util-8.3.8.tgz"
   integrity sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==
 
-"@pwrdrvr/microapps-app-nextjs-demo-cdk@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@pwrdrvr/microapps-app-nextjs-demo-cdk/-/microapps-app-nextjs-demo-cdk-0.2.1.tgz"
-  integrity sha512-YAIhb/430pvvi0NlJSqAzE7tNSVtweSMRnBU4HY+8IwWJnwO8b5HVkfgUhb6aT6B6tx7FUEPY1+tDQoanCOAqg==
+"@pwrdrvr/microapps-app-nextjs-demo-cdk@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@pwrdrvr/microapps-app-nextjs-demo-cdk/-/microapps-app-nextjs-demo-cdk-0.3.1.tgz#f4928ddc143282a6b0cf990d5b2def917b3c30cb"
+  integrity sha512-JutFBa1wj5TaA2C94IRkVGAUbsRfrOHxr+nuH18wTY2O9ulG2+UstTeXMN5cTZKJvrvHwQSXD2KSr/V8064Awg==
   dependencies:
     aws-cdk-lib "^2.8.0"
     constructs "^10.0.5"
 
-"@pwrdrvr/microapps-app-release-cdk@^0.2.2":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@pwrdrvr/microapps-app-release-cdk/-/microapps-app-release-cdk-0.2.4.tgz"
-  integrity sha512-DS/9IP92HO34lfSmP/ZzxuU6HWjUbj00tmEn7opO5n8AO61+7oj+PwzXwjtE2lOJZoYc7v++Yo6IYPq0UoyDGg==
+"@pwrdrvr/microapps-app-release-cdk@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@pwrdrvr/microapps-app-release-cdk/-/microapps-app-release-cdk-0.4.0.tgz#6014fed2efda28cbeac9c4795b05ceabd22c3c89"
+  integrity sha512-+HUs1YLo9HJgxkyRSAMSX/e/ienF74ttRw37sR5LMtiIbLDK50A+hWwSY9qHtkNIFPkRkVRlYd6raMhTaEQx/A==
   dependencies:
     aws-cdk-lib "^2.8.0"
     constructs "^10.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2336,10 +2336,10 @@
     aws-cdk-lib "^2.8.0"
     constructs "^10.0.5"
 
-"@pwrdrvr/microapps-app-release-cdk@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@pwrdrvr/microapps-app-release-cdk/-/microapps-app-release-cdk-0.4.0.tgz#6014fed2efda28cbeac9c4795b05ceabd22c3c89"
-  integrity sha512-+HUs1YLo9HJgxkyRSAMSX/e/ienF74ttRw37sR5LMtiIbLDK50A+hWwSY9qHtkNIFPkRkVRlYd6raMhTaEQx/A==
+"@pwrdrvr/microapps-app-release-cdk@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@pwrdrvr/microapps-app-release-cdk/-/microapps-app-release-cdk-0.4.2.tgz#59e48d99928fbb073a7d0408bba0a8fc45a81f2d"
+  integrity sha512-7Fx/j/FsyGwo9PYVKvvYtFP3y8WSEcR4bz8ntAqOHki6jm2bSz5fgerfu5fjWSt1+hpOqIQ3tihIPo+NvxXkBw==
   dependencies:
     aws-cdk-lib "^2.8.0"
     constructs "^10.0.5"


### PR DESCRIPTION
- Invoke the release app with direct invocation (no `iframe`)
- Pass `removalPolicy` to the table construct for PR cleanups
- Completely remove the sharp layer
- `nextjs-demo` has a bug with the prefix deploy where the initial page load works but then a client-side route change adds `/js-demo/js-demo/` into the path