### PR TITLE
Add `createAlias` capability indicator

### DIFF
--- a/packages/microapps-deployer-lib/src/index.ts
+++ b/packages/microapps-deployer-lib/src/index.ts
@@ -75,7 +75,10 @@ export interface IDeployVersionRequest extends IDeployVersionRequestBase {
    */
   readonly startupType?: 'iframe' | 'direct';
   /**
-   * LambdaARN w/Alias
+   * LambdaARN
+   * - With Alias suffix, used directly
+   * - With Version suffix, Alias will be updated or created for semVer
+   *
    * Used for `lambda` and `lambda-url` apps
    */
   readonly lambdaARN?: string;
@@ -103,6 +106,7 @@ export interface IDeleteVersionRequest
  * Represents a Deployer Response
  */
 export interface IDeployerResponse {
+  readonly capabilities?: { readonly createAlias: 'true' };
   readonly statusCode: number;
 }
 

--- a/packages/microapps-deployer/src/controllers/VersionController.ts
+++ b/packages/microapps-deployer/src/controllers/VersionController.ts
@@ -43,6 +43,7 @@ export default class VersionController {
   }): Promise<IDeployVersionPreflightResponse> {
     const { dbManager, request, config } = opts;
     const { appName, semVer, needS3Creds = true, overwrite = false } = request;
+    const capabilities = { createAlias: 'true' };
 
     // Check if the version exists
     const record = await Version.LoadVersion({
@@ -62,7 +63,7 @@ export default class VersionController {
           semVer: request.semVer,
         });
 
-        return { statusCode: 200 };
+        return { statusCode: 200, capabilities };
       } else {
         Log.Instance.info('Warning: App/Version already exists', {
           appName: request.appName,
@@ -117,6 +118,7 @@ export default class VersionController {
 
       return {
         statusCode: 404,
+        capabilities,
         s3UploadUrl: `s3://${config.filestore.stagingBucket}/${VersionController.GetBucketPrefix(
           request,
           config,
@@ -132,6 +134,7 @@ export default class VersionController {
       Log.Instance.info('finished request - not returning s3 creds');
 
       return {
+        capabilities,
         statusCode: 404,
       };
     }

--- a/packages/microapps-publish/src/commands/publish.ts
+++ b/packages/microapps-publish/src/commands/publish.ts
@@ -229,7 +229,7 @@ export class PublishCommand extends Command {
         },
         {
           enabled: () => !!appLambdaName,
-          title: 'Check if Lambda ARN has Alias',
+          title: 'Check if Lambda ARN has Alias or Version',
           task: (ctx, task) => {
             if (appLambdaName.match(/:/g)?.length === 7) {
               if (/^[0-9]+$/.test(appLambdaName.substring(appLambdaName.lastIndexOf(':') + 1))) {
@@ -248,7 +248,9 @@ export class PublishCommand extends Command {
         },
         {
           enabled: (ctx) =>
-            ctx.configLambdaArnType === 'function' || ctx.configLambdaArnType === 'version',
+            (ctx.configLambdaArnType === 'function' || ctx.configLambdaArnType === 'version') &&
+            // If the deployer service can create aliases, let it
+            ctx.preflightResult.response.capabilities?.['createAlias'] !== 'true',
           title: 'Create Lambda Alias and, optionally, Version',
           task: async (ctx, task) => {
             // Allow overwriting a non-overwritable app if the prior


### PR DESCRIPTION
- Should fail to deploy as deployer svc will fail when it receives a Version not an Alias