### PR TITLE
Fix assume role policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,46 @@ jobs:
       - name: Run Lint
         run: yarn lint
 
+      # - name: Run Node Tests
+      #   env:
+      #     NODE_ENV: test
+      #   run: yarn test
+
+  test:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Cache Node Modules
+        id: cache-node-modules
+        uses: actions/cache@v3
+        with:
+          path: |
+            node_modules
+            packages/**/node_modules
+          key: node-modules-${{ hashFiles('package.json', 'yarn.lock', '**/yarn.lock') }}
+
+      - name: Cache TypeScript Build Output
+        id: cache-typescript-build
+        uses: actions/cache@v3
+        with:
+          path: |
+            packages/**/dist
+            packages/microapps-cdk/lib
+          key: typescript-build-${{ hashFiles('package.json', 'yarn.lock', 'tsconfig.json', 'tsconfig.packages.json', 'packages/**/tsconfig.json', 'packages/**/*.ts') }}
+
+      # These take 2 minutes on GHA
+      # Locally they take 16 seconds (M2 Max)
+      # Possible speedup: may need to replace jest-dynalite and switch to each
+      # test (or at least suite) creating a uniquely named table in a shared
+      # local dynamodb instance.
       - name: Run Node Tests
         env:
           NODE_ENV: test

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "clean:super": "npm run clean:dist && npm run clean:modules && npm run clean:tsbuildinfo",
     "clean:dist": "npm exec --workspaces -- npx rimraf dist && npx rimraf dist",
     "clean:modules": "npm exec --workspaces -- npx rimraf node_modules && npx rimraf node_modules",
-    "clean:tsbuildinfo": "npm exec --workspaces -- npx rimraf \"*.tsbuildinfo\"",
+    "clean:tsbuildinfo": "npm exec --workspaces -- npx rimraf tsconfig.tsbuildinfo",
     "cloc": "cloc --exclude-dir=node_modules,dist,distb,cdk.out --exclude-ext=json .",
     "format": "prettier --write \"packages/**/*.{js,ts}\"",
     "start:publish": "node packages/microapps-publish/dist/src/index.js",

--- a/packages/cdk/lib/MicroApps.ts
+++ b/packages/cdk/lib/MicroApps.ts
@@ -159,7 +159,7 @@ export interface MicroAppsStackProps extends StackProps {
    *
    * @default []
    */
-  readonly parentEdgeToOriginRoleArns?: string[];
+  // readonly parentEdgeToOriginRoleArns?: string[];
 }
 
 export class MicroAppsStack extends Stack {
@@ -194,7 +194,6 @@ export class MicroAppsStack extends Stack {
       tableName,
       childDeployenRoleArns = [],
       allowedFunctionUrlAccounts = [],
-      parentEdgeToOriginRoleArns = [],
     } = props;
 
     let removalPolicy: RemovalPolicy | undefined = undefined;
@@ -279,8 +278,8 @@ export class MicroAppsStack extends Stack {
       version: microapps.svcs.deployerFunc.currentVersion,
     });
     // Allow cross-account invokes if specified
-    // TODO: Actually handle the list of account ID
-    if (childDeployenRoleArns.length > 0) {
+    // TODO: Actually handle the list of account IDs
+    if (childDeployenRoleArns?.length > 0) {
       const childRole = iam.Role.fromRoleArn(this, 'deployer-child-role', childDeployenRoleArns[0]);
 
       microapps.svcs.deployerFunc.addPermission('deployer-child-permission', {

--- a/packages/microapps-cdk/src/MicroAppsEdgeToOrigin.ts
+++ b/packages/microapps-cdk/src/MicroAppsEdgeToOrigin.ts
@@ -252,7 +252,10 @@ class MicroAppsEdgeToOriginRoleStack extends Stack {
     });
     this._role.assumeRolePolicy?.addStatements(
       new iam.PolicyStatement({
-        principals: [new iam.ServicePrincipal('edgelambda.amazonaws.com')],
+        principals: [
+          new iam.ServicePrincipal('edgelambda.amazonaws.com'),
+          new iam.ServicePrincipal('lambda.amazonaws.com'),
+        ],
         actions: ['sts:AssumeRole'],
         effect: iam.Effect.ALLOW,
       }),


### PR DESCRIPTION
- Builds on main failed after merging child account support
  - At least one of the failures is the missing `lambda.amazonaws.com` principal being allowed to assume the lambda role
  - There may be another problem with the computed child deployer Role ARN
- Tests take too long on GHA, holding up dev deploy - Split out
- Fix `clean:tsbuildinfo` (for real this time)