### PR TITLE
Issue 323 - Fix throw on GetAlias when lambda is gone

### DIFF
--- a/packages/microapps-cdk/src/MicroAppsChildDeployer.ts
+++ b/packages/microapps-cdk/src/MicroAppsChildDeployer.ts
@@ -187,5 +187,14 @@ export class MicroAppsChildDeployer extends Construct implements IMicroAppsChild
       },
     });
     this._deployerFunc.addToRolePolicy(policyAPIManageLambdas);
+    const policyReadonlyLambdas = new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: ['lambda:GetFunction', 'lambda:GetAlias'],
+      resources: [
+        `arn:aws:lambda:${Aws.REGION}:${Aws.ACCOUNT_ID}:function:*`,
+        `arn:aws:lambda:${Aws.REGION}:${Aws.ACCOUNT_ID}:function:*:*`,
+      ],
+    });
+    this._deployerFunc.addToRolePolicy(policyReadonlyLambdas);
   }
 }


### PR DESCRIPTION
- When a lambda doesn't exist the Tag `microapp-managed` is clearly missing too
- This means the deployer has no permission to even GetAlias, which causes it to throw permission denied instead of resource not found
- Give the deployer service permission to GetAlias and GetFunction on any lambda