### PR TITLE
Issue 328 - Multiple Invoke Roles

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
-import { App, Environment } from 'aws-cdk-lib';
+import { App, Aws, Environment } from 'aws-cdk-lib';
 import { MicroAppsStack } from '../lib/MicroApps';
 import { MicroAppsChildStack } from '../lib/MicroAppsChild';
 import { MicroAppsChildPrivStack } from '../lib/MicroAppsChildPriv';
@@ -34,6 +34,15 @@ new MicroAppsStack(app, 'microapps-core', {
   deployDemoApp: shared.deployDemoApp,
   deployNextjsDemoApp: shared.deployNextjsDemoApp,
   deployReleaseApp: shared.deployReleaseApp,
+  // Allow the primary deployment to call child apps on PRs
+  // as a demo of providing an additional allowed IAM Role
+  ...(shared.isPR
+    ? {
+        edgeToOriginRoleARNs: [
+          `arn:aws:iam::${Aws.ACCOUNT_ID}:role/microapps-core-ghpublic-edge-role${shared.envSuffix}`,
+        ],
+      }
+    : {}),
   // We need to know the origin region for signing requests
   // Accessing Aws.REGION will end up writing a Token into the config file
   originRegion: shared.region,

--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -51,7 +51,7 @@ new MicroAppsChildStack(app, 'microapps-core-child', {
   assetNameRoot: 'microapps-core-ghchild',
   assetNameSuffix: `${shared.envSuffix}${shared.prSuffix}`,
   parentDeployerLambdaARN: process.env.PARENT_DEPLOYER_LAMBDA_ARN || '',
-  edgeToOriginRoleARN: process.env.EDGE_TO_ORIGIN_ROLE_ARN || '',
+  edgeToOriginRoleARN: process.env.EDGE_TO_ORIGIN_ROLE_ARN,
 });
 
 new MicroAppsChildPrivStack(app, 'microapps-core-child-priv', {

--- a/packages/cdk/lib/MicroApps.ts
+++ b/packages/cdk/lib/MicroApps.ts
@@ -142,6 +142,11 @@ export interface MicroAppsStackProps extends StackProps {
    * @default []
    */
   readonly allowedFunctionUrlAccounts?: string[];
+
+  /**
+   * Additional IAM Role ARNs that should be allowed to invoke apps in child accounts
+   */
+  readonly edgeToOriginRoleARNs?: string[];
 }
 
 export class MicroAppsStack extends Stack {
@@ -175,6 +180,7 @@ export class MicroAppsStack extends Stack {
       originRegion,
       tableName,
       allowedFunctionUrlAccounts = [],
+      edgeToOriginRoleARNs = [],
     } = props;
 
     let removalPolicy: RemovalPolicy | undefined = undefined;
@@ -249,6 +255,7 @@ export class MicroAppsStack extends Stack {
       tableNameForEdgeToOrigin: tableName ? tableName : `${assetNameRoot}${assetNameSuffix}`,
       allowedFunctionUrlAccounts,
       allowedLocalePrefixes: ['en', 'sv'],
+      edgeToOriginRoleARNs,
       ...optionalAssetNameOpts,
       ...optionals3PolicyOpts,
       ...optionalCustomDomainOpts,

--- a/packages/cdk/lib/MicroAppsChild.ts
+++ b/packages/cdk/lib/MicroAppsChild.ts
@@ -17,8 +17,10 @@ export interface MicroAppsChildStackProps extends StackProps {
 
   /**
    * ARN of the IAM Role for the Edge to Origin Lambda Function
+   *
+   * For child accounts this can be blank as it is retrieved from the parent Deployer
    */
-  readonly edgeToOriginRoleARN: string;
+  readonly edgeToOriginRoleARN?: string;
 
   /**
    * Automatically destroy all assets when stack is deleted

--- a/packages/microapps-cdk/API.md
+++ b/packages/microapps-cdk/API.md
@@ -979,14 +979,6 @@ Application environment, passed as `NODE_ENV` to the Router and Deployer Lambda 
 
 ---
 
-##### `edgeToOriginRoleARN`<sup>Required</sup> <a name="@pwrdrvr/microapps-cdk.MicroAppsChildDeployerProps.edgeToOriginRoleARN"></a>
-
-- *Type:* `string`
-
-ARN of the IAM Role for the Edge to Origin Lambda Function.
-
----
-
 ##### `parentDeployerLambdaARN`<sup>Required</sup> <a name="@pwrdrvr/microapps-cdk.MicroAppsChildDeployerProps.parentDeployerLambdaARN"></a>
 
 - *Type:* `string`
@@ -1021,6 +1013,16 @@ Optional asset name suffix.
 Deployer timeout.
 
 For larger applications this needs to be set up to 2-5 minutes for the S3 copy
+
+---
+
+##### `edgeToOriginRoleARN`<sup>Optional</sup> <a name="@pwrdrvr/microapps-cdk.MicroAppsChildDeployerProps.edgeToOriginRoleARN"></a>
+
+- *Type:* `string`
+
+ARN of the IAM Role for the Edge to Origin Lambda Function.
+
+For child accounts this can be blank as it is retrieved from the parent Deployer
 
 ---
 
@@ -1327,6 +1329,14 @@ Optional custom domain name for the API Gateway HTTPv2 API.
 - *Type:* [`aws-cdk-lib.aws_cloudfront.EdgeLambda`](#aws-cdk-lib.aws_cloudfront.EdgeLambda)[]
 
 Additional edge lambda functions.
+
+---
+
+##### `edgeToOriginRoleARNs`<sup>Optional</sup> <a name="@pwrdrvr/microapps-cdk.MicroAppsProps.edgeToOriginRoleARNs"></a>
+
+- *Type:* `string`[]
+
+Additional IAM Role ARNs that should be allowed to invoke apps in child accounts.
 
 ---
 
@@ -1652,6 +1662,14 @@ Optional asset name suffix.
 Deployer timeout.
 
 For larger applications this needs to be set up to 2-5 minutes for the S3 copy
+
+---
+
+##### `edgeToOriginRoleARN`<sup>Optional</sup> <a name="@pwrdrvr/microapps-cdk.MicroAppsSvcsProps.edgeToOriginRoleARN"></a>
+
+- *Type:* `string`[]
+
+ARN of the IAM Role for the Edge to Origin Lambda Function.
 
 ---
 

--- a/packages/microapps-cdk/API.md
+++ b/packages/microapps-cdk/API.md
@@ -1432,7 +1432,7 @@ of applying the Deny Rule to roles from other accounts.
 
 To get the AROA with the AWS CLI:
    aws iam get-role --role-name ROLE-NAME
-   aws iam get-user -–user-name USER-NAME
+   aws iam get-user --user-name USER-NAME
 
 > s3StrictBucketPolicy
 
@@ -1730,7 +1730,7 @@ of applying the Deny Rule to roles from other accounts.
 
 To get the AROA with the AWS CLI:
    aws iam get-role --role-name ROLE-NAME
-   aws iam get-user -–user-name USER-NAME
+   aws iam get-user --user-name USER-NAME
 
 > s3StrictBucketPolicy
 

--- a/packages/microapps-cdk/src/MicroApps.ts
+++ b/packages/microapps-cdk/src/MicroApps.ts
@@ -310,6 +310,11 @@ export interface MicroAppsProps {
    * @default none
    */
   readonly allowedLocalePrefixes?: string[];
+
+  /**
+   * Additional IAM Role ARNs that should be allowed to invoke apps in child accounts
+   */
+  readonly edgeToOriginRoleARNs?: string[];
 }
 
 /**
@@ -410,6 +415,7 @@ export class MicroApps extends Construct implements IMicroApps {
       tableNameForEdgeToOrigin,
       originShieldRegion = originRegion,
       allowedFunctionUrlAccounts = [],
+      edgeToOriginRoleARNs = [],
     } = props;
 
     this._s3 = new MicroAppsS3(this, 's3', {
@@ -451,6 +457,7 @@ export class MicroApps extends Construct implements IMicroApps {
       rootPathPrefix,
       requireIAMAuthorization: signingMode !== 'none',
       table,
+      edgeToOriginRoleARN: edgeToOriginRoleARNs,
     });
     const edgeLambdas: cf.EdgeLambda[] = [];
 

--- a/packages/microapps-cdk/src/MicroApps.ts
+++ b/packages/microapps-cdk/src/MicroApps.ts
@@ -147,7 +147,7 @@ export interface MicroAppsProps {
    *
    * To get the AROA with the AWS CLI:
    *   aws iam get-role --role-name ROLE-NAME
-   *   aws iam get-user -–user-name USER-NAME
+   *   aws iam get-user --user-name USER-NAME
    *
    * @example [ 'AROA1234567890123' ]
    *

--- a/packages/microapps-cdk/src/MicroAppsChildDeployer.ts
+++ b/packages/microapps-cdk/src/MicroAppsChildDeployer.ts
@@ -18,8 +18,10 @@ export interface MicroAppsChildDeployerProps {
 
   /**
    * ARN of the IAM Role for the Edge to Origin Lambda Function
+   *
+   * For child accounts this can be blank as it is retrieved from the parent Deployer
    */
-  readonly edgeToOriginRoleARN: string;
+  readonly edgeToOriginRoleARN?: string;
 
   /**
    * RemovalPolicy override for child resources
@@ -139,7 +141,7 @@ export class MicroAppsChildDeployer extends Construct implements IMicroAppsChild
         NODE_ENV: appEnv,
         AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
         PARENT_DEPLOYER_LAMBDA_ARN: parentDeployerLambdaARN,
-        EDGE_TO_ORIGIN_ROLE_ARN: edgeToOriginRoleARN,
+        ...(edgeToOriginRoleARN ? { EDGE_TO_ORIGIN_ROLE_ARN: edgeToOriginRoleARN } : {}),
       },
     };
     if (

--- a/packages/microapps-cdk/src/MicroAppsSvcs.ts
+++ b/packages/microapps-cdk/src/MicroAppsSvcs.ts
@@ -463,7 +463,7 @@ export class MicroAppsSvcs extends Construct implements IMicroAppsSvcs {
         //
         // To get the AROA with the AWS CLI:
         //   aws iam get-role --role-name ROLE-NAME
-        //   aws iam get-user -–user-name USER-NAME
+        //   aws iam get-user --user-name USER-NAME
         StringNotLike: { 'aws:userid': [Aws.ACCOUNT_ID, ...s3PolicyBypassAROAMatches] },
       },
     });

--- a/packages/microapps-cdk/src/MicroAppsSvcs.ts
+++ b/packages/microapps-cdk/src/MicroAppsSvcs.ts
@@ -131,7 +131,7 @@ export interface MicroAppsSvcsProps {
    *
    * To get the AROA with the AWS CLI:
    *   aws iam get-role --role-name ROLE-NAME
-   *   aws iam get-user -–user-name USER-NAME
+   *   aws iam get-user --user-name USER-NAME
    *
    * @example [ 'AROA1234567890123' ]
    *
@@ -178,6 +178,11 @@ export interface MicroAppsSvcsProps {
    * @default 2 minutes
    */
   readonly deployerTimeout?: Duration;
+
+  /**
+   * ARN of the IAM Role for the Edge to Origin Lambda Function
+   */
+  readonly edgeToOriginRoleARN?: string[];
 }
 
 /**
@@ -243,6 +248,7 @@ export class MicroAppsSvcs extends Construct implements IMicroAppsSvcs {
       assetNameSuffix,
       rootPathPrefix = '',
       requireIAMAuthorization = true,
+      edgeToOriginRoleARN,
     } = props;
 
     if (s3StrictBucketPolicy === true) {
@@ -315,6 +321,7 @@ export class MicroAppsSvcs extends Construct implements IMicroAppsSvcs {
         AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
         ROOT_PATH_PREFIX: rootPathPrefix,
         REQUIRE_IAM_AUTHORIZATION: requireIAMAuthorization ? 'true' : 'false',
+        ...(edgeToOriginRoleARN ? { EDGE_TO_ORIGIN_ROLE_ARN: edgeToOriginRoleARN.join(',') } : {}),
       },
     };
     if (

--- a/packages/microapps-deployer-lib/src/messages/base.ts
+++ b/packages/microapps-deployer-lib/src/messages/base.ts
@@ -25,7 +25,8 @@ export interface IRequestBase {
     | 'deployVersionLite'
     | 'deployVersionPreflight'
     | 'getVersion'
-    | 'lambdaAlias';
+    | 'lambdaAlias'
+    | 'getConfig';
 }
 
 /**

--- a/packages/microapps-deployer-lib/src/messages/deployer.ts
+++ b/packages/microapps-deployer-lib/src/messages/deployer.ts
@@ -1,3 +1,5 @@
-import { IResponseBase } from './base';
+import { IRequestBase, IResponseBase } from './base';
 
 export type IDeployerResponse = IResponseBase;
+
+export type IDeployerRequest = IRequestBase;

--- a/packages/microapps-deployer-lib/src/messages/get-config.ts
+++ b/packages/microapps-deployer-lib/src/messages/get-config.ts
@@ -1,0 +1,21 @@
+import { IDeployerResponse, IDeployerRequest } from './deployer';
+
+/**
+ * Represents a Get Config Request
+ */
+export interface IGetConfigRequest extends IDeployerRequest {
+  readonly type: 'getConfig';
+}
+
+/**
+ * Represents a Get Config Response
+ */
+export interface IGetConfigResponse extends IDeployerResponse {
+  readonly type: 'getConfig';
+
+  /**
+   * Origin Request Role ARNs that should be allowed to call
+   * all application versions using IAM Auth.
+   */
+  readonly originRequestRoleARNs: string[];
+}

--- a/packages/microapps-deployer-lib/src/messages/index.ts
+++ b/packages/microapps-deployer-lib/src/messages/index.ts
@@ -3,6 +3,7 @@ export * from './create-app';
 export * from './delete-version';
 export * from './deploy-version';
 export * from './deployer';
+export * from './get-config';
 export * from './get-version';
 export * from './lambda-alias';
 export * from './preflight';

--- a/packages/microapps-deployer/src/config/Config.ts
+++ b/packages/microapps-deployer/src/config/Config.ts
@@ -9,7 +9,7 @@ import { FileStore, IFileStore } from './FileStore';
 
 const StringArray = {
   name: 'StringArray',
-  coerce: (v: string) => v.split(','),
+  coerce: (v: string) => (v ?? '').split(','),
   validate: () => {
     // do nothing
   },

--- a/packages/microapps-deployer/src/config/Config.ts
+++ b/packages/microapps-deployer/src/config/Config.ts
@@ -7,6 +7,14 @@ import { APIGateway, IAPIGateway } from './APIGateway';
 import { Database, IDatabase } from './Database';
 import { FileStore, IFileStore } from './FileStore';
 
+const StringArray = {
+  name: 'StringArray',
+  coerce: (v: string) => v.split(','),
+  validate: () => {
+    // do nothing
+  },
+};
+
 /**
  * Represents a Config
  */
@@ -45,6 +53,7 @@ export interface IConfig {
   formats: {
     url,
     ipaddress,
+    StringArray,
   },
 })
 export class Config implements IConfig {
@@ -142,6 +151,7 @@ export class Config implements IConfig {
     doc: 'ARN of the Role used by the Edge to Origin Lambda function to invoke the app',
     default: '',
     env: 'EDGE_TO_ORIGIN_ROLE_ARN',
+    format: 'StringArray',
   })
   public edgeToOriginRoleARN!: string[];
 }

--- a/packages/microapps-deployer/src/config/Config.ts
+++ b/packages/microapps-deployer/src/config/Config.ts
@@ -19,7 +19,7 @@ export interface IConfig {
   readonly awsRegion: string;
 
   readonly parentDeployerLambdaARN?: string;
-  readonly edgeToOriginRoleARN?: string;
+  readonly edgeToOriginRoleARN?: string[];
 
   readonly uploadRoleName: string;
 
@@ -143,5 +143,5 @@ export class Config implements IConfig {
     default: '',
     env: 'EDGE_TO_ORIGIN_ROLE_ARN',
   })
-  public edgeToOriginRoleARN!: string;
+  public edgeToOriginRoleARN!: string[];
 }

--- a/packages/microapps-deployer/src/controllers/ConfigController.ts
+++ b/packages/microapps-deployer/src/controllers/ConfigController.ts
@@ -1,0 +1,24 @@
+import type { IGetConfigRequest, IGetConfigResponse } from '@pwrdrvr/microapps-deployer-lib';
+import { IConfig } from '../config/Config';
+
+export default class ConfigController {
+  public static GetConfig(opts: {
+    request: IGetConfigRequest;
+    config: IConfig;
+  }): IGetConfigResponse {
+    const { config, request } = opts;
+
+    if (request.type !== 'getConfig') {
+      throw new Error('Invalid request type');
+    }
+
+    // Return the list of origin request role ARNs
+    return {
+      statusCode: 200,
+      type: 'getConfig',
+      originRequestRoleARNs: Array.isArray(config.edgeToOriginRoleARN)
+        ? (config.edgeToOriginRoleARN as string[])
+        : [config.edgeToOriginRoleARN ?? ''],
+    };
+  }
+}

--- a/packages/microapps-deployer/src/controllers/ConfigController.ts
+++ b/packages/microapps-deployer/src/controllers/ConfigController.ts
@@ -18,7 +18,9 @@ export default class ConfigController {
       type: 'getConfig',
       originRequestRoleARNs: Array.isArray(config.edgeToOriginRoleARN)
         ? (config.edgeToOriginRoleARN as string[])
-        : [config.edgeToOriginRoleARN ?? ''],
+        : config.edgeToOriginRoleARN
+        ? [config.edgeToOriginRoleARN]
+        : [],
     };
   }
 }

--- a/packages/microapps-deployer/src/controllers/version/LambdaAlias.spec.ts
+++ b/packages/microapps-deployer/src/controllers/version/LambdaAlias.spec.ts
@@ -1,5 +1,6 @@
 /// <reference types="jest" />
 import 'reflect-metadata';
+import { createHash } from 'crypto';
 import 'jest-dynalite/withDb';
 import { Config, IConfig } from '../../config/Config';
 jest.mock('../../config/Config');
@@ -201,10 +202,34 @@ describe('LambdaAlias', () => {
             }),
           ),
         })
+        .on(lambda.GetPolicyCommand, {
+          FunctionName: fakeLambdaARNBase,
+          Qualifier: fakeLambdaAlias,
+        })
+        .resolves({
+          Policy: JSON.stringify({
+            Version: '2012-10-17',
+            Statement: [
+              // {
+              //   Action: 'lambda:InvokeFunctionUrl',
+              //   Principal: roleToAdd,
+              // StatementId: `microapps-edge-to-origin-${roleArnHash}`,
+              // FunctionName: lambdaBaseARN,
+              // Qualifier: lambdaAlias,
+              //   Condition: {
+              //     ArnLike: {
+              //       'AWS:SourceArn': 'arn:aws:execute-api:us-east-1:123456789012:123/*',
+            ],
+          }),
+        })
         .on(lambda.AddPermissionCommand, {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           Principal: config.edgeToOriginRoleARN![0],
-          StatementId: `microapps-edge-to-origin`,
+          StatementId: `microapps-edge-to-origin-${createHash('sha256')
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            .update(config.edgeToOriginRoleARN![0])
+            .digest('hex')
+            .substring(0, 8)}`,
           Action: 'lambda:InvokeFunctionUrl',
           FunctionName: fakeLambdaARNBase,
           Qualifier: fakeLambdaAlias,
@@ -215,9 +240,11 @@ describe('LambdaAlias', () => {
           },
         })
         .on(lambda.AddPermissionCommand, {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           Principal: extraOriginRoleARN,
-          StatementId: `microapps-edge-to-origin-1`,
+          StatementId: `microapps-edge-to-origin-${createHash('sha256')
+            .update(extraOriginRoleARN)
+            .digest('hex')
+            .substring(0, 8)}`,
           Action: 'lambda:InvokeFunctionUrl',
           FunctionName: fakeLambdaARNBase,
           Qualifier: fakeLambdaAlias,
@@ -242,7 +269,7 @@ describe('LambdaAlias', () => {
       expect(response.type).toBe('lambdaAlias');
       expect(response.lambdaAliasARN).toBe(`${fakeLambdaARNBase}:${fakeLambdaAlias}`);
       expect(response.functionUrl).toBe('https://fakeurl.com');
-      expect(lambdaClient.calls()).toHaveLength(9);
+      expect(lambdaClient.calls()).toHaveLength(10);
     });
 
     it('handles parent deployer not supporting getConfig request', async () => {
@@ -332,19 +359,30 @@ describe('LambdaAlias', () => {
             }),
           ),
         })
-        .on(lambda.AddPermissionCommand, {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          Principal: config.edgeToOriginRoleARN![0],
-          StatementId: `microapps-edge-to-origin`,
-          Action: 'lambda:InvokeFunctionUrl',
+        .on(lambda.GetPolicyCommand, {
           FunctionName: fakeLambdaARNBase,
           Qualifier: fakeLambdaAlias,
         })
         .resolves({
-          $metadata: {
-            httpStatusCode: 200,
-          },
+          Policy: JSON.stringify({
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Action: 'lambda:InvokeFunctionUrl',
+                Principal: {
+                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                  AWS: config.edgeToOriginRoleARN![0],
+                },
+                Sid: `microapps-edge-to-origin-${createHash('sha256')
+                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                  .update(config.edgeToOriginRoleARN![0])
+                  .digest('hex')
+                  .substring(0, 8)}`,
+              },
+            ],
+          }),
         });
+
       const request: ILambdaAliasRequest = {
         appName,
         semVer,
@@ -451,10 +489,34 @@ describe('LambdaAlias', () => {
             }),
           ),
         })
+        .on(lambda.GetPolicyCommand, {
+          FunctionName: fakeLambdaARNBase,
+          Qualifier: fakeLambdaAlias,
+        })
+        .resolves({
+          Policy: JSON.stringify({
+            Version: '2012-10-17',
+            Statement: [
+              // {
+              //   Action: 'lambda:InvokeFunctionUrl',
+              //   Principal: roleToAdd,
+              // StatementId: `microapps-edge-to-origin-${roleArnHash}`,
+              // FunctionName: lambdaBaseARN,
+              // Qualifier: lambdaAlias,
+              //   Condition: {
+              //     ArnLike: {
+              //       'AWS:SourceArn': 'arn:aws:execute-api:us-east-1:123456789012:123/*',
+            ],
+          }),
+        })
         .on(lambda.AddPermissionCommand, {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           Principal: config.edgeToOriginRoleARN![0],
-          StatementId: `microapps-edge-to-origin`,
+          StatementId: `microapps-edge-to-origin-${createHash('sha256')
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            .update(config.edgeToOriginRoleARN![0])
+            .digest('hex')
+            .substring(0, 8)}`,
           Action: 'lambda:InvokeFunctionUrl',
           FunctionName: fakeLambdaARNBase,
           Qualifier: fakeLambdaAlias,
@@ -479,7 +541,7 @@ describe('LambdaAlias', () => {
       expect(response.type).toBe('lambdaAlias');
       expect(response.lambdaAliasARN).toBe(`${fakeLambdaARNBase}:${fakeLambdaAlias}`);
       expect(response.functionUrl).toBe('https://fakeurl.com');
-      expect(lambdaClient.calls()).toHaveLength(8);
+      expect(lambdaClient.calls()).toHaveLength(9);
     });
   });
 

--- a/packages/microapps-deployer/src/controllers/version/LambdaAlias.spec.ts
+++ b/packages/microapps-deployer/src/controllers/version/LambdaAlias.spec.ts
@@ -244,6 +244,243 @@ describe('LambdaAlias', () => {
       expect(response.functionUrl).toBe('https://fakeurl.com');
       expect(lambdaClient.calls()).toHaveLength(9);
     });
+
+    it('handles parent deployer not supporting getConfig request', async () => {
+      // @ts-expect-error We want to overwrite this
+      config.parentDeployerLambdaARN =
+        'arn:aws:lambda:us-east-1:123456789012:function:parent-deployer';
+      // @ts-expect-error We want to overwrite this
+      config.edgeToOriginRoleARN = ['arn:aws:iam::123456789012:role/edge-to-origin'];
+
+      const appName = 'newapp';
+      const semVer = '0.0.0';
+      const fakeLambdaVersion = '31';
+      const fakeLambdaARNWithVersion = `${fakeLambdaARNBase}:${fakeLambdaVersion}`;
+      const fakeLambdaAlias = 'v0_0_0';
+
+      s3Client.onAnyCommand().rejects();
+      stsClient.onAnyCommand().rejects();
+      lambdaClient
+        .onAnyCommand()
+        .rejects()
+        .on(lambda.GetFunctionCommand, {
+          FunctionName: fakeLambdaARNBase,
+          Qualifier: fakeLambdaVersion,
+        })
+        .resolves({
+          Configuration: {
+            LastUpdateStatus: 'Successful',
+            FunctionArn: `${fakeLambdaARNBase}:${fakeLambdaVersion}`,
+          },
+        })
+        .on(lambda.GetAliasCommand, {
+          FunctionName: fakeLambdaARNBase,
+          Name: fakeLambdaAlias,
+        })
+        .rejects({
+          name: 'ResourceNotFoundException',
+        })
+        .on(lambda.CreateAliasCommand, {
+          FunctionName: fakeLambdaARNBase,
+          Name: fakeLambdaAlias,
+          FunctionVersion: fakeLambdaVersion,
+        })
+        .resolves({
+          AliasArn: `${fakeLambdaARNBase}:${fakeLambdaAlias}`,
+          FunctionVersion: fakeLambdaVersion,
+        })
+        // AddTagToFunction
+        .on(lambda.ListTagsCommand, {
+          Resource: fakeLambdaARNBase,
+        })
+        .resolves({
+          Tags: {
+            'app-name': appName,
+            'sem-ver': semVer,
+          },
+        })
+        .on(lambda.TagResourceCommand, {
+          Resource: fakeLambdaARNBase,
+          Tags: {
+            'microapp-managed': 'true',
+          },
+        })
+        .resolves({})
+        // AddOrUpdateFunctionUrl
+        .on(lambda.GetFunctionUrlConfigCommand, {
+          FunctionName: fakeLambdaARNBase,
+          Qualifier: fakeLambdaAlias,
+        })
+        .resolves({
+          FunctionUrl: 'https://fakeurl.com',
+        })
+        .on(lambda.InvokeCommand, {
+          FunctionName: config.parentDeployerLambdaARN,
+          Payload: Buffer.from(
+            JSON.stringify({
+              type: 'getConfig',
+            }),
+          ),
+        })
+        .resolves({
+          $metadata: {
+            httpStatusCode: 200,
+          },
+          Payload: Buffer.from(
+            JSON.stringify({
+              statusCode: 400,
+            }),
+          ),
+        })
+        .on(lambda.AddPermissionCommand, {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          Principal: config.edgeToOriginRoleARN![0],
+          StatementId: `microapps-edge-to-origin`,
+          Action: 'lambda:InvokeFunctionUrl',
+          FunctionName: fakeLambdaARNBase,
+          Qualifier: fakeLambdaAlias,
+        })
+        .resolves({
+          $metadata: {
+            httpStatusCode: 200,
+          },
+        });
+      const request: ILambdaAliasRequest = {
+        appName,
+        semVer,
+        lambdaARN: fakeLambdaARNWithVersion,
+        type: 'lambdaAlias',
+      };
+      const response = (await handler(request, {
+        awsRequestId: '123',
+      } as lambdaTypes.Context)) as ILambdaAliasResponse;
+
+      expect(response.statusCode).toBe(201);
+      expect(response.type).toBe('lambdaAlias');
+      expect(response.lambdaAliasARN).toBe(`${fakeLambdaARNBase}:${fakeLambdaAlias}`);
+      expect(response.functionUrl).toBe('https://fakeurl.com');
+      expect(lambdaClient.calls()).toHaveLength(8);
+    });
+
+    it('handles parent deployer returning no additional roles', async () => {
+      // @ts-expect-error We want to overwrite this
+      config.parentDeployerLambdaARN =
+        'arn:aws:lambda:us-east-1:123456789012:function:parent-deployer';
+      // @ts-expect-error We want to overwrite this
+      config.edgeToOriginRoleARN = ['arn:aws:iam::123456789012:role/edge-to-origin'];
+
+      const appName = 'newapp';
+      const semVer = '0.0.0';
+      const fakeLambdaVersion = '31';
+      const fakeLambdaARNWithVersion = `${fakeLambdaARNBase}:${fakeLambdaVersion}`;
+      const fakeLambdaAlias = 'v0_0_0';
+
+      s3Client.onAnyCommand().rejects();
+      stsClient.onAnyCommand().rejects();
+      lambdaClient
+        .onAnyCommand()
+        .rejects()
+        .on(lambda.GetFunctionCommand, {
+          FunctionName: fakeLambdaARNBase,
+          Qualifier: fakeLambdaVersion,
+        })
+        .resolves({
+          Configuration: {
+            LastUpdateStatus: 'Successful',
+            FunctionArn: `${fakeLambdaARNBase}:${fakeLambdaVersion}`,
+          },
+        })
+        .on(lambda.GetAliasCommand, {
+          FunctionName: fakeLambdaARNBase,
+          Name: fakeLambdaAlias,
+        })
+        .rejects({
+          name: 'ResourceNotFoundException',
+        })
+        .on(lambda.CreateAliasCommand, {
+          FunctionName: fakeLambdaARNBase,
+          Name: fakeLambdaAlias,
+          FunctionVersion: fakeLambdaVersion,
+        })
+        .resolves({
+          AliasArn: `${fakeLambdaARNBase}:${fakeLambdaAlias}`,
+          FunctionVersion: fakeLambdaVersion,
+        })
+        // AddTagToFunction
+        .on(lambda.ListTagsCommand, {
+          Resource: fakeLambdaARNBase,
+        })
+        .resolves({
+          Tags: {
+            'app-name': appName,
+            'sem-ver': semVer,
+          },
+        })
+        .on(lambda.TagResourceCommand, {
+          Resource: fakeLambdaARNBase,
+          Tags: {
+            'microapp-managed': 'true',
+          },
+        })
+        .resolves({})
+        // AddOrUpdateFunctionUrl
+        .on(lambda.GetFunctionUrlConfigCommand, {
+          FunctionName: fakeLambdaARNBase,
+          Qualifier: fakeLambdaAlias,
+        })
+        .resolves({
+          FunctionUrl: 'https://fakeurl.com',
+        })
+        .on(lambda.InvokeCommand, {
+          FunctionName: config.parentDeployerLambdaARN,
+          Payload: Buffer.from(
+            JSON.stringify({
+              type: 'getConfig',
+            }),
+          ),
+        })
+        .resolves({
+          $metadata: {
+            httpStatusCode: 200,
+          },
+          Payload: Buffer.from(
+            JSON.stringify({
+              statusCode: 200,
+              type: 'getConfig',
+              originRequestRoleARNs: [''],
+            }),
+          ),
+        })
+        .on(lambda.AddPermissionCommand, {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          Principal: config.edgeToOriginRoleARN![0],
+          StatementId: `microapps-edge-to-origin`,
+          Action: 'lambda:InvokeFunctionUrl',
+          FunctionName: fakeLambdaARNBase,
+          Qualifier: fakeLambdaAlias,
+        })
+        .resolves({
+          $metadata: {
+            httpStatusCode: 200,
+          },
+        });
+
+      const request: ILambdaAliasRequest = {
+        appName,
+        semVer,
+        lambdaARN: fakeLambdaARNWithVersion,
+        type: 'lambdaAlias',
+      };
+      const response = (await handler(request, {
+        awsRequestId: '123',
+      } as lambdaTypes.Context)) as ILambdaAliasResponse;
+
+      expect(response.statusCode).toBe(201);
+      expect(response.type).toBe('lambdaAlias');
+      expect(response.lambdaAliasARN).toBe(`${fakeLambdaARNBase}:${fakeLambdaAlias}`);
+      expect(response.functionUrl).toBe('https://fakeurl.com');
+      expect(lambdaClient.calls()).toHaveLength(8);
+    });
   });
 
   describe('lambdaAlias - version ARN passed', () => {

--- a/packages/microapps-deployer/src/controllers/version/LambdaAlias.ts
+++ b/packages/microapps-deployer/src/controllers/version/LambdaAlias.ts
@@ -387,6 +387,7 @@ async function AddCrossAccountPermissionsToAlias({
   const response = await lambdaClient.send(
     new lambda.InvokeCommand({
       FunctionName: config.parentDeployerLambdaARN,
+      Qualifier: 'currentVersion',
       Payload: Buffer.from(JSON.stringify(request)),
     }),
   );

--- a/packages/microapps-deployer/src/controllers/version/LambdaAlias.ts
+++ b/packages/microapps-deployer/src/controllers/version/LambdaAlias.ts
@@ -379,8 +379,11 @@ async function AddCrossAccountPermissionsToAlias({
     return;
   }
 
-  // TODO: Call the parent Deployer to get the list of Role ARNs that are allowed
-  let originRequestRoleARNs: string[] = [];
+  // Call the parent Deployer to get the additional list of Role ARNs that are allowed
+  const originRequestRoleARNs: string[] =
+    config.edgeToOriginRoleARN && config.edgeToOriginRoleARN.length > 0
+      ? [...config.edgeToOriginRoleARN]
+      : [];
   const request: IGetConfigRequest = {
     type: 'getConfig',
   };
@@ -400,7 +403,7 @@ async function AddCrossAccountPermissionsToAlias({
     }
 
     if (dResponse.originRequestRoleARNs && dResponse.originRequestRoleARNs.length > 0) {
-      originRequestRoleARNs = dResponse.originRequestRoleARNs;
+      originRequestRoleARNs.push(...dResponse.originRequestRoleARNs);
     }
   } else {
     throw new Error(

--- a/packages/microapps-deployer/src/controllers/version/LambdaAlias.ts
+++ b/packages/microapps-deployer/src/controllers/version/LambdaAlias.ts
@@ -377,6 +377,8 @@ async function AddCrossAccountPermissionsToAlias({
     return;
   }
 
+  // TODO: Call the parent Deployer to get the list of Role ARNs that are allowed
+
   //
   // Confirm edge-to-origin is already allowed to execute this alias
   // from the specific route for this version

--- a/packages/microapps-deployer/src/controllers/version/LambdaAlias.ts
+++ b/packages/microapps-deployer/src/controllers/version/LambdaAlias.ts
@@ -398,12 +398,19 @@ async function AddCrossAccountPermissionsToAlias({
     const dResponse = JSON.parse(
       Buffer.from(response.Payload).toString('utf-8'),
     ) as IGetConfigResponse;
-    if (!(dResponse.statusCode === 200)) {
-      throw new Error(`Get config failed: ${JSON.stringify(dResponse)}`);
-    }
+    if (dResponse.statusCode !== 400) {
+      if (!(dResponse.statusCode === 200)) {
+        throw new Error(`Get config failed: ${JSON.stringify(dResponse)}`);
+      }
 
-    if (dResponse.originRequestRoleARNs && dResponse.originRequestRoleARNs.length > 0) {
-      originRequestRoleARNs.push(...dResponse.originRequestRoleARNs);
+      if (dResponse.originRequestRoleARNs && dResponse.originRequestRoleARNs.length > 0) {
+        const filteredRoles = dResponse.originRequestRoleARNs.filter(
+          (value) => value && !originRequestRoleARNs.includes(value),
+        );
+        if (filteredRoles.length > 0) {
+          originRequestRoleARNs.push(...filteredRoles);
+        }
+      }
     }
   } else {
     throw new Error(

--- a/packages/microapps-deployer/src/index.ts
+++ b/packages/microapps-deployer/src/index.ts
@@ -10,6 +10,7 @@ import type {
   IDeleteVersionRequest,
   ILambdaAliasRequest,
   IGetVersionRequest,
+  IGetConfigRequest,
 } from '@pwrdrvr/microapps-deployer-lib';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { LambdaClient, InvokeCommand } from '@aws-sdk/client-lambda';
@@ -17,6 +18,7 @@ import { DBManager } from '@pwrdrvr/microapps-datalib';
 import * as lambda from 'aws-lambda';
 import { Config } from './config/Config';
 import AppController from './controllers/AppController';
+import ConfigController from './controllers/ConfigController';
 import {
   DeleteVersion,
   DeployVersion,
@@ -143,6 +145,11 @@ export async function handler(
       case 'getVersion': {
         const request = event as IGetVersionRequest;
         return await GetVersion({ dbManager, request, config });
+      }
+
+      case 'getConfig': {
+        const request = event as IGetConfigRequest;
+        return ConfigController.GetConfig({ request, config });
       }
 
       case 'lambdaAlias': {

--- a/packages/microapps-deployer/src/index.ts
+++ b/packages/microapps-deployer/src/index.ts
@@ -51,6 +51,8 @@ dbManager = new DBManager({ dynamoClient, tableName: Config.instance.db.tableNam
 
 const config = Config.instance;
 
+Log.Instance.info('Deployer config', config);
+
 export async function handler(
   event: IRequestBase,
   context?: lambda.Context,

--- a/packages/microapps-edge-to-origin/src/index.ts
+++ b/packages/microapps-edge-to-origin/src/index.ts
@@ -129,13 +129,13 @@ export const handler: lambda.CloudFrontRequestHandler = async (
         normalizedPathPrefix,
       });
 
-      log.info('got route info', { route });
+      log.debug('got route info', { route });
 
       // Write the app iframe to start an iframe-based app
       if (route.startupType === 'iframe' && route.iFrameAppVersionPath) {
         const frameHTML = appFrame.replace('{{iframeSrc}}', route.iFrameAppVersionPath);
 
-        log.info('returning app frame', { frameHTML });
+        log.debug('returning app frame', { frameHTML });
 
         return {
           status: '200',
@@ -168,7 +168,7 @@ export const handler: lambda.CloudFrontRequestHandler = async (
 
       // Fall through to apigwy handling if type is not url
       if (route.url && (route.type === 'url' || route.type === 'lambda-url')) {
-        log.info('rewriting to url', { url: route.url });
+        log.debug('rewriting to url', { url: route.url });
 
         routeType = route.type;
 
@@ -275,7 +275,7 @@ export const handler: lambda.CloudFrontRequestHandler = async (
     // when customized, so we can only rely on the Lambda URL check.
     const signer = originHost.includes('.lambda-url.') ? lambdaSigner : executeApiSigner;
     if (config.signingMode === 'sign') {
-      log.info('signing request');
+      log.debug('signing request');
       const signedRequest = await signRequest(request, context, signer);
       requestToReturn = signedRequest;
     } else if (config.signingMode === 'presign') {

--- a/packages/microapps-edge-to-origin/src/index.ts
+++ b/packages/microapps-edge-to-origin/src/index.ts
@@ -81,7 +81,7 @@ export const handler: lambda.CloudFrontRequestHandler = async (
       request.origin?.s3?.domainName &&
       request.origin?.s3?.customHeaders['x-microapps-origin']?.[0]?.value === 's3'
     ) {
-      log.info('request is for S3 origin', { request });
+      log.debug('request is for S3 origin', { request });
 
       if (
         request.headers['host']?.[0]?.value &&


### PR DESCRIPTION
- Allow multiple roles to invoke the app lambdas
- Fixes #328 
- Add unit tests for a child deployer lambda invoking the parent deployer lambda
- Add unit tests for adding permissions to the app lambda alias resource policy