### PR TITLE
Fix cdk version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -577,7 +577,7 @@ jobs:
           npm run test:integration
 
   build-jsii:
-    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && contains( github.event.pull_request.labels.*.name, 'BUILD-JSII')) || (github.event_name == 'pull_request' && github.actor == 'dependabot[bot]')
+    # if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && contains( github.event.pull_request.labels.*.name, 'BUILD-JSII')) || (github.event_name == 'pull_request' && github.actor == 'dependabot[bot]')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,16 @@ env:
   AWS_REGION: us-east-2
 
 jobs:
+  install-deps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/configure-nodejs
+        with:
+          lookup-only: 'true' # We only want to lookup from the cache - if a hit, this job does nothing
+
   build:
+    needs: [install-deps]
     runs-on: ubuntu-latest
     outputs:
       prSuffix: ${{ steps.prSuffix.outputs.prSuffix }}
@@ -578,6 +587,7 @@ jobs:
 
   build-jsii:
     # if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && contains( github.event.pull_request.labels.*.name, 'BUILD-JSII')) || (github.event_name == 'pull_request' && github.actor == 'dependabot[bot]')
+    needs: [install-deps]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -16,8 +16,17 @@ on:
   #     - main
 
 jobs:
+  install-deps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/configure-nodejs
+        with:
+          lookup-only: 'true' # We only want to lookup from the cache - if a hit, this job does nothing
+
   build:
     name: Build CDK Construct
+    needs: [install-deps]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,20 @@ on:
   release:
     types: [published]
 jobs:
+  install-deps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/configure-nodejs
+        with:
+          lookup-only: 'true' # We only want to lookup from the cache - if a hit, this job does nothing
+
   #
   # CDK Construct
   #
   release:
     name: Build CDK Construct
+    needs: [install-deps]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/packages/microapps-cdk/.projen/deps.json
+++ b/packages/microapps-cdk/.projen/deps.json
@@ -79,7 +79,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "2.95.0",
+      "version": "^2.95.0",
       "type": "peer"
     },
     {

--- a/packages/microapps-cdk/.projen/tasks.json
+++ b/packages/microapps-cdk/.projen/tasks.json
@@ -305,13 +305,13 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,@types/yargs,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,esbuild,eslint-import-resolver-typescript,eslint-plugin-import,eslint,jsii-diff,jsii-docgen,jsii-pacmak,jsii-rosetta,jsii,projen,standard-version,typescript,constructs"
+          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,@types/yargs,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,esbuild,eslint-import-resolver-typescript,eslint-plugin-import,eslint,jsii-diff,jsii-docgen,jsii-pacmak,jsii-rosetta,jsii,projen,standard-version,typescript,aws-cdk-lib,constructs"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @types/jest @types/node @types/yargs @typescript-eslint/eslint-plugin @typescript-eslint/parser esbuild eslint-import-resolver-typescript eslint-plugin-import eslint jsii-diff jsii-docgen jsii-pacmak jsii-rosetta jsii projen standard-version typescript constructs"
+          "exec": "yarn upgrade @types/jest @types/node @types/yargs @typescript-eslint/eslint-plugin @typescript-eslint/parser esbuild eslint-import-resolver-typescript eslint-plugin-import eslint jsii-diff jsii-docgen jsii-pacmak jsii-rosetta jsii projen standard-version typescript aws-cdk-lib constructs"
         },
         {
           "exec": "npx projen"

--- a/packages/microapps-cdk/.projenrc.js
+++ b/packages/microapps-cdk/.projenrc.js
@@ -7,7 +7,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   description:
     'MicroApps framework, by PwrDrvr LLC, delivered as an AWS CDK construct that provides the DynamoDB, Router service, Deploy service, API Gateway, and CloudFront distribution.',
   cdkVersion: '2.95.0',
-  cdkVersionPinning: true,
+  cdkVersionPinning: false,
   copyrightOwner: 'PwrDrvr LLC',
   copyrightPeriod: '2020',
   defaultReleaseBranch: 'main',

--- a/packages/microapps-cdk/package.json
+++ b/packages/microapps-cdk/package.json
@@ -58,7 +58,7 @@
     "typescript": "^5.3.2"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "2.95.0",
+    "aws-cdk-lib": "^2.95.0",
     "constructs": "^10.0.5"
   },
   "keywords": [


### PR DESCRIPTION
- Stop telling projen to pin the version of CDK to an exact version
- Populate module cache once and restoring cache when simply checking if it exists
- Always build JSII