### PR TITLE
refactor(cdk): remove deprecated origin and log APIs

### DIFF
--- a/packages/cdk/lib/DemoApp.ts
+++ b/packages/cdk/lib/DemoApp.ts
@@ -69,12 +69,20 @@ export class DemoApp extends Construct implements IDemoApp {
     //
     // Lambda Function
     //
+    const lambdaFunctionName = assetNameRoot
+      ? `${assetNameRoot}-app-${appName}${assetNameSuffix}`
+      : undefined;
+    const demoAppLogGroup = new logs.LogGroup(this, 'app-lambda-log-group', {
+      logGroupName: lambdaFunctionName ? `/aws/lambda/${lambdaFunctionName}` : undefined,
+      retention: logs.RetentionDays.ONE_WEEK,
+      removalPolicy,
+    });
     this._lambdaFunction = new lambdaNodejs.NodejsFunction(this, 'app-lambda', {
       entry: './packages/demo-app/src/index.ts',
       runtime: lambda.Runtime.NODEJS_22_X,
       handler: 'handler',
-      functionName: assetNameRoot ? `${assetNameRoot}-app-${appName}${assetNameSuffix}` : undefined,
-      logRetention: logs.RetentionDays.ONE_WEEK,
+      functionName: lambdaFunctionName,
+      logGroup: demoAppLogGroup,
       memorySize: 512,
       timeout: Duration.seconds(3),
       bundling: {

--- a/packages/cdk/test/MicroApps.spec.ts
+++ b/packages/cdk/test/MicroApps.spec.ts
@@ -15,7 +15,7 @@ describe('MicroAppsStack', () => {
 
     expect(stack).toBeDefined();
     Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function', {});
-    Template.fromStack(stack).resourceCountIs('AWS::Lambda::Function', 3);
+    Template.fromStack(stack).resourceCountIs('AWS::Lambda::Function', 2);
     Template.fromStack(stack).hasOutput('edgedomainname', {
       Value: { 'Fn::GetAtt': ['microappscft5FDF8AB8', 'DomainName'] },
       Export: { Name: `${stackName}-edge-domain-name` },
@@ -46,7 +46,7 @@ describe('MicroAppsStack', () => {
 
     expect(stack).toBeDefined();
     Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function', {});
-    Template.fromStack(stack).resourceCountIs('AWS::Lambda::Function', 3);
+    Template.fromStack(stack).resourceCountIs('AWS::Lambda::Function', 2);
     Template.fromStack(stack).hasOutput('edgedomainname', {
       Value: 'appz.pwrdrvr.com',
       Export: { Name: `${stackName}-edge-domain-name` },

--- a/packages/microapps-cdk/API.md
+++ b/packages/microapps-cdk/API.md
@@ -885,8 +885,8 @@ Any object.
 | <code><a href="#@pwrdrvr/microapps-cdk.MicroAppsS3.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@pwrdrvr/microapps-cdk.MicroAppsS3.property.bucketApps">bucketApps</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | S3 bucket for deployed applications. |
 | <code><a href="#@pwrdrvr/microapps-cdk.MicroAppsS3.property.bucketAppsOAI">bucketAppsOAI</a></code> | <code>aws-cdk-lib.aws_cloudfront.OriginAccessIdentity</code> | CloudFront Origin Access Identity for the deployed applications bucket. |
-| <code><a href="#@pwrdrvr/microapps-cdk.MicroAppsS3.property.bucketAppsOriginApp">bucketAppsOriginApp</a></code> | <code>aws-cdk-lib.aws_cloudfront_origins.S3Origin</code> | CloudFront Origin for the deployed applications bucket Marked with `x-microapps-origin: app` so the OriginRequest function knows to send the request to the application origin first, if configured for a particular application. |
-| <code><a href="#@pwrdrvr/microapps-cdk.MicroAppsS3.property.bucketAppsOriginS3">bucketAppsOriginS3</a></code> | <code>aws-cdk-lib.aws_cloudfront_origins.S3Origin</code> | CloudFront Origin for the deployed applications bucket Marked with `x-microapps-origin: s3` so the OriginRequest function knows to NOT send the request to the application origin and instead let it fall through to the S3 bucket. |
+| <code><a href="#@pwrdrvr/microapps-cdk.MicroAppsS3.property.bucketAppsOriginApp">bucketAppsOriginApp</a></code> | <code>aws-cdk-lib.aws_cloudfront.IOrigin</code> | CloudFront Origin for the deployed applications bucket Marked with `x-microapps-origin: app` so the OriginRequest function knows to send the request to the application origin first, if configured for a particular application. |
+| <code><a href="#@pwrdrvr/microapps-cdk.MicroAppsS3.property.bucketAppsOriginS3">bucketAppsOriginS3</a></code> | <code>aws-cdk-lib.aws_cloudfront.IOrigin</code> | CloudFront Origin for the deployed applications bucket Marked with `x-microapps-origin: s3` so the OriginRequest function knows to NOT send the request to the application origin and instead let it fall through to the S3 bucket. |
 | <code><a href="#@pwrdrvr/microapps-cdk.MicroAppsS3.property.bucketAppsStaging">bucketAppsStaging</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | S3 bucket for staged applications (prior to deploy). |
 | <code><a href="#@pwrdrvr/microapps-cdk.MicroAppsS3.property.bucketLogs">bucketLogs</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | S3 bucket for CloudFront logs. |
 
@@ -931,10 +931,10 @@ CloudFront Origin Access Identity for the deployed applications bucket.
 ##### `bucketAppsOriginApp`<sup>Required</sup> <a name="bucketAppsOriginApp" id="@pwrdrvr/microapps-cdk.MicroAppsS3.property.bucketAppsOriginApp"></a>
 
 ```typescript
-public readonly bucketAppsOriginApp: S3Origin;
+public readonly bucketAppsOriginApp: IOrigin;
 ```
 
-- *Type:* aws-cdk-lib.aws_cloudfront_origins.S3Origin
+- *Type:* aws-cdk-lib.aws_cloudfront.IOrigin
 
 CloudFront Origin for the deployed applications bucket Marked with `x-microapps-origin: app` so the OriginRequest function knows to send the request to the application origin first, if configured for a particular application.
 
@@ -943,10 +943,10 @@ CloudFront Origin for the deployed applications bucket Marked with `x-microapps-
 ##### `bucketAppsOriginS3`<sup>Required</sup> <a name="bucketAppsOriginS3" id="@pwrdrvr/microapps-cdk.MicroAppsS3.property.bucketAppsOriginS3"></a>
 
 ```typescript
-public readonly bucketAppsOriginS3: S3Origin;
+public readonly bucketAppsOriginS3: IOrigin;
 ```
 
-- *Type:* aws-cdk-lib.aws_cloudfront_origins.S3Origin
+- *Type:* aws-cdk-lib.aws_cloudfront.IOrigin
 
 CloudFront Origin for the deployed applications bucket Marked with `x-microapps-origin: s3` so the OriginRequest function knows to NOT send the request to the application origin and instead let it fall through to the S3 bucket.
 
@@ -1627,8 +1627,8 @@ const microAppsCFProps: MicroAppsCFProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#@pwrdrvr/microapps-cdk.MicroAppsCFProps.property.bucketAppsOriginApp">bucketAppsOriginApp</a></code> | <code>aws-cdk-lib.aws_cloudfront_origins.S3Origin</code> | S3 bucket origin for deployed applications Marked with `x-microapps-origin: app`. |
-| <code><a href="#@pwrdrvr/microapps-cdk.MicroAppsCFProps.property.bucketAppsOriginS3">bucketAppsOriginS3</a></code> | <code>aws-cdk-lib.aws_cloudfront_origins.S3Origin</code> | S3 bucket origin for deployed applications Marked with `x-microapps-origin: s3`. |
+| <code><a href="#@pwrdrvr/microapps-cdk.MicroAppsCFProps.property.bucketAppsOriginApp">bucketAppsOriginApp</a></code> | <code>aws-cdk-lib.aws_cloudfront.IOrigin</code> | S3 bucket origin for deployed applications Marked with `x-microapps-origin: app`. |
+| <code><a href="#@pwrdrvr/microapps-cdk.MicroAppsCFProps.property.bucketAppsOriginS3">bucketAppsOriginS3</a></code> | <code>aws-cdk-lib.aws_cloudfront.IOrigin</code> | S3 bucket origin for deployed applications Marked with `x-microapps-origin: s3`. |
 | <code><a href="#@pwrdrvr/microapps-cdk.MicroAppsCFProps.property.assetNameRoot">assetNameRoot</a></code> | <code>string</code> | Optional asset name root. |
 | <code><a href="#@pwrdrvr/microapps-cdk.MicroAppsCFProps.property.assetNameSuffix">assetNameSuffix</a></code> | <code>string</code> | Optional asset name suffix. |
 | <code><a href="#@pwrdrvr/microapps-cdk.MicroAppsCFProps.property.bucketLogs">bucketLogs</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | S3 bucket for CloudFront logs. |
@@ -1648,10 +1648,10 @@ const microAppsCFProps: MicroAppsCFProps = { ... }
 ##### `bucketAppsOriginApp`<sup>Required</sup> <a name="bucketAppsOriginApp" id="@pwrdrvr/microapps-cdk.MicroAppsCFProps.property.bucketAppsOriginApp"></a>
 
 ```typescript
-public readonly bucketAppsOriginApp: S3Origin;
+public readonly bucketAppsOriginApp: IOrigin;
 ```
 
-- *Type:* aws-cdk-lib.aws_cloudfront_origins.S3Origin
+- *Type:* aws-cdk-lib.aws_cloudfront.IOrigin
 
 S3 bucket origin for deployed applications Marked with `x-microapps-origin: app`.
 
@@ -1660,10 +1660,10 @@ S3 bucket origin for deployed applications Marked with `x-microapps-origin: app`
 ##### `bucketAppsOriginS3`<sup>Required</sup> <a name="bucketAppsOriginS3" id="@pwrdrvr/microapps-cdk.MicroAppsCFProps.property.bucketAppsOriginS3"></a>
 
 ```typescript
-public readonly bucketAppsOriginS3: S3Origin;
+public readonly bucketAppsOriginS3: IOrigin;
 ```
 
-- *Type:* aws-cdk-lib.aws_cloudfront_origins.S3Origin
+- *Type:* aws-cdk-lib.aws_cloudfront.IOrigin
 
 S3 bucket origin for deployed applications Marked with `x-microapps-origin: s3`.
 
@@ -3499,8 +3499,8 @@ Represents a MicroApps S3.
 | --- | --- | --- |
 | <code><a href="#@pwrdrvr/microapps-cdk.IMicroAppsS3.property.bucketApps">bucketApps</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | S3 bucket for deployed applications. |
 | <code><a href="#@pwrdrvr/microapps-cdk.IMicroAppsS3.property.bucketAppsOAI">bucketAppsOAI</a></code> | <code>aws-cdk-lib.aws_cloudfront.OriginAccessIdentity</code> | CloudFront Origin Access Identity for the deployed applications bucket. |
-| <code><a href="#@pwrdrvr/microapps-cdk.IMicroAppsS3.property.bucketAppsOriginApp">bucketAppsOriginApp</a></code> | <code>aws-cdk-lib.aws_cloudfront_origins.S3Origin</code> | CloudFront Origin for the deployed applications bucket Marked with `x-microapps-origin: app` so the OriginRequest function knows to send the request to the application origin first, if configured for a particular application. |
-| <code><a href="#@pwrdrvr/microapps-cdk.IMicroAppsS3.property.bucketAppsOriginS3">bucketAppsOriginS3</a></code> | <code>aws-cdk-lib.aws_cloudfront_origins.S3Origin</code> | CloudFront Origin for the deployed applications bucket Marked with `x-microapps-origin: s3` so the OriginRequest function knows to NOT send the request to the application origin and instead let it fall through to the S3 bucket. |
+| <code><a href="#@pwrdrvr/microapps-cdk.IMicroAppsS3.property.bucketAppsOriginApp">bucketAppsOriginApp</a></code> | <code>aws-cdk-lib.aws_cloudfront.IOrigin</code> | CloudFront Origin for the deployed applications bucket Marked with `x-microapps-origin: app` so the OriginRequest function knows to send the request to the application origin first, if configured for a particular application. |
+| <code><a href="#@pwrdrvr/microapps-cdk.IMicroAppsS3.property.bucketAppsOriginS3">bucketAppsOriginS3</a></code> | <code>aws-cdk-lib.aws_cloudfront.IOrigin</code> | CloudFront Origin for the deployed applications bucket Marked with `x-microapps-origin: s3` so the OriginRequest function knows to NOT send the request to the application origin and instead let it fall through to the S3 bucket. |
 | <code><a href="#@pwrdrvr/microapps-cdk.IMicroAppsS3.property.bucketAppsStaging">bucketAppsStaging</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | S3 bucket for staged applications (prior to deploy). |
 | <code><a href="#@pwrdrvr/microapps-cdk.IMicroAppsS3.property.bucketLogs">bucketLogs</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | S3 bucket for CloudFront logs. |
 
@@ -3533,10 +3533,10 @@ CloudFront Origin Access Identity for the deployed applications bucket.
 ##### `bucketAppsOriginApp`<sup>Required</sup> <a name="bucketAppsOriginApp" id="@pwrdrvr/microapps-cdk.IMicroAppsS3.property.bucketAppsOriginApp"></a>
 
 ```typescript
-public readonly bucketAppsOriginApp: S3Origin;
+public readonly bucketAppsOriginApp: IOrigin;
 ```
 
-- *Type:* aws-cdk-lib.aws_cloudfront_origins.S3Origin
+- *Type:* aws-cdk-lib.aws_cloudfront.IOrigin
 
 CloudFront Origin for the deployed applications bucket Marked with `x-microapps-origin: app` so the OriginRequest function knows to send the request to the application origin first, if configured for a particular application.
 
@@ -3545,10 +3545,10 @@ CloudFront Origin for the deployed applications bucket Marked with `x-microapps-
 ##### `bucketAppsOriginS3`<sup>Required</sup> <a name="bucketAppsOriginS3" id="@pwrdrvr/microapps-cdk.IMicroAppsS3.property.bucketAppsOriginS3"></a>
 
 ```typescript
-public readonly bucketAppsOriginS3: S3Origin;
+public readonly bucketAppsOriginS3: IOrigin;
 ```
 
-- *Type:* aws-cdk-lib.aws_cloudfront_origins.S3Origin
+- *Type:* aws-cdk-lib.aws_cloudfront.IOrigin
 
 CloudFront Origin for the deployed applications bucket Marked with `x-microapps-origin: s3` so the OriginRequest function knows to NOT send the request to the application origin and instead let it fall through to the S3 bucket.
 

--- a/packages/microapps-cdk/src/MicroAppsCF.ts
+++ b/packages/microapps-cdk/src/MicroAppsCF.ts
@@ -36,13 +36,13 @@ export interface MicroAppsCFProps {
    * S3 bucket origin for deployed applications
    * Marked with `x-microapps-origin: s3`
    */
-  readonly bucketAppsOriginS3: cforigins.S3Origin;
+  readonly bucketAppsOriginS3: cf.IOrigin;
 
   /**
    * S3 bucket origin for deployed applications
    * Marked with `x-microapps-origin: app`
    */
-  readonly bucketAppsOriginApp: cforigins.S3Origin;
+  readonly bucketAppsOriginApp: cf.IOrigin;
 
   /**
    * S3 bucket for CloudFront logs

--- a/packages/microapps-cdk/src/MicroAppsChildDeployer.ts
+++ b/packages/microapps-cdk/src/MicroAppsChildDeployer.ts
@@ -130,11 +130,16 @@ export class MicroAppsChildDeployer extends Construct implements IMicroAppsChild
     const deployerFuncName = assetNameRoot
       ? `${assetNameRoot}-deployer${assetNameSuffix}`
       : undefined;
+    const deployerLogGroup = new logs.LogGroup(this, 'deployer-log-group', {
+      logGroupName: deployerFuncName ? `/aws/lambda/${deployerFuncName}` : undefined,
+      retention: logs.RetentionDays.ONE_MONTH,
+      removalPolicy,
+    });
     const deployerFuncProps: Omit<lambda.FunctionProps, 'handler' | 'code'> = {
       functionName: deployerFuncName,
       role: iamRoleDeployer,
       memorySize: 1769,
-      logRetention: logs.RetentionDays.ONE_MONTH,
+      logGroup: deployerLogGroup,
       runtime: lambda.Runtime.NODEJS_22_X,
       timeout: deployerTimeout,
       environment: {

--- a/packages/microapps-cdk/src/MicroAppsEdgeToOrigin.ts
+++ b/packages/microapps-cdk/src/MicroAppsEdgeToOrigin.ts
@@ -374,12 +374,13 @@ ${
     // Create the Edge to Origin Function
     //
     const edgeToOriginFuncProps: Omit<lambda.FunctionProps, 'handler' | 'code'> = {
-      functionName: assetNameRoot ? `${assetNameRoot}-edge-to-origin${assetNameSuffix}` : undefined,
       role: this._edgeToOriginRole,
       memorySize: 1769,
-      logRetention: logs.RetentionDays.ONE_MONTH,
       runtime: lambda.Runtime.NODEJS_22_X,
       timeout: Duration.seconds(5),
+      ...(assetNameRoot
+        ? { functionName: `${assetNameRoot}-edge-to-origin${assetNameSuffix}` }
+        : {}),
       ...(removalPolicy ? { removalPolicy } : {}),
     };
     const rootDistPath = path.join(__dirname, '..', '..', 'microapps-edge-to-origin', 'dist');
@@ -393,6 +394,7 @@ ${
         rootDistPath,
         edgeToOriginConfigYaml,
         edgeToOriginFuncProps,
+        removalPolicy,
       );
     } else if (localDistExists) {
       // Prefer local dist above root dist if both exist (when building for distribution)
@@ -400,6 +402,7 @@ ${
         localDistPath,
         edgeToOriginConfigYaml,
         edgeToOriginFuncProps,
+        removalPolicy,
       );
     } else if (rootDistExists) {
       // Use local dist if it exists (when deploying from CDK in this repo)
@@ -407,6 +410,7 @@ ${
         rootDistPath,
         edgeToOriginConfigYaml,
         edgeToOriginFuncProps,
+        removalPolicy,
       );
     } else {
       // This is used when bundling the app and building the CDK module
@@ -499,6 +503,7 @@ ${
     distPath: string,
     edgeToOriginConfigYaml: string,
     edgeToOriginFuncProps: Omit<lambda.FunctionProps, 'handler' | 'code'>,
+    removalPolicy?: RemovalPolicy,
   ) {
     writeFileSync(path.join(distPath, 'config.yml'), edgeToOriginConfigYaml);
 
@@ -520,12 +525,19 @@ ${
 
     // EdgeFunction has a bug where it will generate the same parameter
     // name across multiple stacks in the same region if the id param is constant
+    const effectiveFunctionName =
+      edgeToOriginFuncProps.functionName ?? `microapps-edge-to-origin-${stackHash}`;
     const edge = new cf.experimental.EdgeFunction(this, `edge-to-apigwy-func-${stackHash}`, {
       stackId: `microapps-edge-to-origin-${stackHash}`,
       code,
-      functionName: `microapps-edge-to-origin-${stackHash}`,
+      functionName: effectiveFunctionName,
       handler: 'index.handler',
       ...edgeToOriginFuncProps,
+    });
+    new logs.LogGroup(edge.stack, `edge-to-origin-log-group-${stackHash}`, {
+      logGroupName: `/aws/lambda/${effectiveFunctionName}`,
+      retention: logs.RetentionDays.ONE_MONTH,
+      ...(removalPolicy ? { removalPolicy } : {}),
     });
     Tags.of(edge).add('Name', Stack.of(this).stackName);
 

--- a/packages/microapps-cdk/src/MicroAppsS3.ts
+++ b/packages/microapps-cdk/src/MicroAppsS3.ts
@@ -24,7 +24,7 @@ export interface IMicroAppsS3 {
    * knows to send the request to the application origin first, if configured
    * for a particular application.
    */
-  readonly bucketAppsOriginApp: cforigins.S3Origin;
+  readonly bucketAppsOriginApp: cf.IOrigin;
 
   /**
    * CloudFront Origin for the deployed applications bucket
@@ -32,7 +32,7 @@ export interface IMicroAppsS3 {
    * knows to NOT send the request to the application origin and instead
    * let it fall through to the S3 bucket.
    */
-  readonly bucketAppsOriginS3: cforigins.S3Origin;
+  readonly bucketAppsOriginS3: cf.IOrigin;
 
   /**
    * S3 bucket for staged applications (prior to deploy)
@@ -123,13 +123,13 @@ export class MicroAppsS3 extends Construct implements IMicroAppsS3 {
     return this._bucketAppsOAI;
   }
 
-  private _bucketAppsOriginApp: cforigins.S3Origin;
-  public get bucketAppsOriginApp(): cforigins.S3Origin {
+  private _bucketAppsOriginApp: cf.IOrigin;
+  public get bucketAppsOriginApp(): cf.IOrigin {
     return this._bucketAppsOriginApp;
   }
 
-  private _bucketAppsOriginS3: cforigins.S3Origin;
-  public get bucketAppsOriginS3(): cforigins.S3Origin {
+  private _bucketAppsOriginS3: cf.IOrigin;
+  public get bucketAppsOriginS3(): cf.IOrigin {
     return this._bucketAppsOriginS3;
   }
 
@@ -189,7 +189,7 @@ export class MicroAppsS3 extends Construct implements IMicroAppsS3 {
     }
 
     // Add Origin for CloudFront
-    this._bucketAppsOriginS3 = new cforigins.S3Origin(this._bucketApps, {
+    this._bucketAppsOriginS3 = cforigins.S3BucketOrigin.withOriginAccessIdentity(this._bucketApps, {
       originAccessIdentity: this.bucketAppsOAI,
       originShieldRegion,
       customHeaders: {
@@ -197,12 +197,15 @@ export class MicroAppsS3 extends Construct implements IMicroAppsS3 {
       },
     });
 
-    this._bucketAppsOriginApp = new cforigins.S3Origin(this._bucketApps, {
-      originAccessIdentity: this.bucketAppsOAI,
-      originShieldRegion,
-      customHeaders: {
-        'x-microapps-origin': 'app',
+    this._bucketAppsOriginApp = cforigins.S3BucketOrigin.withOriginAccessIdentity(
+      this._bucketApps,
+      {
+        originAccessIdentity: this.bucketAppsOAI,
+        originShieldRegion,
+        customHeaders: {
+          'x-microapps-origin': 'app',
+        },
       },
-    });
+    );
   }
 }

--- a/packages/microapps-cdk/src/MicroAppsSvcs.ts
+++ b/packages/microapps-cdk/src/MicroAppsSvcs.ts
@@ -296,11 +296,16 @@ export class MicroAppsSvcs extends Construct implements IMicroAppsSvcs {
     const deployerFuncName = assetNameRoot
       ? `${assetNameRoot}-deployer${assetNameSuffix}`
       : undefined;
+    const deployerLogGroup = new logs.LogGroup(this, 'deployer-log-group', {
+      logGroupName: deployerFuncName ? `/aws/lambda/${deployerFuncName}` : undefined,
+      retention: logs.RetentionDays.ONE_MONTH,
+      removalPolicy,
+    });
     const deployerFuncProps: Omit<lambda.FunctionProps, 'handler' | 'code'> = {
       functionName: deployerFuncName,
       role: iamRoleDeployer,
       memorySize: 1769,
-      logRetention: logs.RetentionDays.ONE_MONTH,
+      logGroup: deployerLogGroup,
       runtime: lambda.Runtime.NODEJS_22_X,
       timeout: deployerTimeout,
       environment: {

--- a/packages/microapps-cdk/test/MicroApps.spec.ts
+++ b/packages/microapps-cdk/test/MicroApps.spec.ts
@@ -29,7 +29,7 @@ describe('MicroApps', () => {
     expect(construct.node).toBeDefined();
     Template.fromStack(stack).resourceCountIs('AWS::DynamoDB::Table', 1);
     Template.fromStack(stack).resourceCountIs('AWS::CloudFront::Distribution', 1);
-    Template.fromStack(stack).resourceCountIs('AWS::Lambda::Function', 3);
+    Template.fromStack(stack).resourceCountIs('AWS::Lambda::Function', 2);
 
     // Confirm that logical IDs have not changed accidentally (causes delete/create)
     Template.fromStack(stack).templateMatches({
@@ -92,7 +92,7 @@ describe('MicroApps', () => {
     expect(construct.node).toBeDefined();
     Template.fromStack(stack).resourceCountIs('AWS::DynamoDB::Table', 1);
     Template.fromStack(stack).resourceCountIs('AWS::CloudFront::Distribution', 1);
-    Template.fromStack(stack).resourceCountIs('AWS::Lambda::Function', 3);
+    Template.fromStack(stack).resourceCountIs('AWS::Lambda::Function', 2);
 
     // Confirm that logical IDs have not changed accidentally (causes delete/create)
     Template.fromStack(stack).templateMatches({
@@ -156,7 +156,7 @@ describe('MicroApps', () => {
     expect(construct.node).toBeDefined();
     Template.fromStack(stack).resourceCountIs('AWS::DynamoDB::Table', 1);
     Template.fromStack(stack).resourceCountIs('AWS::CloudFront::Distribution', 1);
-    Template.fromStack(stack).resourceCountIs('AWS::Lambda::Function', 3);
+    Template.fromStack(stack).resourceCountIs('AWS::Lambda::Function', 2);
     // Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function', {
     //   FunctionName: 'my-asset-root-name-router-some-suffix',
     // });
@@ -227,7 +227,7 @@ describe('MicroApps', () => {
     expect(construct.node).toBeDefined();
     Template.fromStack(stack).resourceCountIs('AWS::DynamoDB::Table', 1);
     Template.fromStack(stack).resourceCountIs('AWS::CloudFront::Distribution', 1);
-    Template.fromStack(stack).resourceCountIs('AWS::Lambda::Function', 3);
+    Template.fromStack(stack).resourceCountIs('AWS::Lambda::Function', 2);
     // Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function', {
     //   FunctionName: 'my-asset-root-name-router-some-suffix',
     // });
@@ -315,7 +315,7 @@ describe('MicroApps', () => {
     expect(construct.node).toBeDefined();
     Template.fromStack(stack).resourceCountIs('AWS::DynamoDB::Table', 1);
     Template.fromStack(stack).resourceCountIs('AWS::CloudFront::Distribution', 1);
-    Template.fromStack(stack).resourceCountIs('AWS::Lambda::Function', 2);
+    Template.fromStack(stack).resourceCountIs('AWS::Lambda::Function', 1);
 
     // Confirm that logical IDs have not changed accidentally (causes delete/create)
     Template.fromStack(stack).templateMatches({

--- a/packages/microapps-cdk/test/MicroAppsCF.spec.ts
+++ b/packages/microapps-cdk/test/MicroAppsCF.spec.ts
@@ -29,13 +29,13 @@ describe('MicroAppsCF', () => {
     const bucket = new s3.Bucket(stack, 'bucket-apps', {});
     const oai = new cf.OriginAccessIdentity(stack, 'oai', {});
     const construct = new MicroAppsCF(stack, 'construct', {
-      bucketAppsOriginApp: new cforigins.S3Origin(bucket, {
+      bucketAppsOriginApp: cforigins.S3BucketOrigin.withOriginAccessIdentity(bucket, {
         customHeaders: {
           'x-microapps-origin': 'app',
         },
         originAccessIdentity: oai,
       }),
-      bucketAppsOriginS3: new cforigins.S3Origin(bucket, {
+      bucketAppsOriginS3: cforigins.S3BucketOrigin.withOriginAccessIdentity(bucket, {
         customHeaders: {
           'x-microapps-origin': 's3',
         },
@@ -66,13 +66,13 @@ describe('MicroAppsCF', () => {
     const bucket = new s3.Bucket(stack, 'bucket-apps', {});
     const oai = new cf.OriginAccessIdentity(stack, 'oai', {});
     const construct = new MicroAppsCF(stack, 'construct', {
-      bucketAppsOriginApp: new cforigins.S3Origin(bucket, {
+      bucketAppsOriginApp: cforigins.S3BucketOrigin.withOriginAccessIdentity(bucket, {
         customHeaders: {
           'x-microapps-origin': 'app',
         },
         originAccessIdentity: oai,
       }),
-      bucketAppsOriginS3: new cforigins.S3Origin(bucket, {
+      bucketAppsOriginS3: cforigins.S3BucketOrigin.withOriginAccessIdentity(bucket, {
         customHeaders: {
           'x-microapps-origin': 's3',
         },
@@ -106,13 +106,13 @@ describe('MicroAppsCF', () => {
     const oai = new cf.OriginAccessIdentity(stack, 'oai', {});
 
     new MicroAppsCF(stack, 'construct', {
-      bucketAppsOriginApp: new cforigins.S3Origin(bucket, {
+      bucketAppsOriginApp: cforigins.S3BucketOrigin.withOriginAccessIdentity(bucket, {
         customHeaders: {
           'x-microapps-origin': 'app',
         },
         originAccessIdentity: oai,
       }),
-      bucketAppsOriginS3: new cforigins.S3Origin(bucket, {
+      bucketAppsOriginS3: cforigins.S3BucketOrigin.withOriginAccessIdentity(bucket, {
         customHeaders: {
           'x-microapps-origin': 's3',
         },
@@ -151,13 +151,13 @@ describe('MicroAppsCF', () => {
     const oai = new cf.OriginAccessIdentity(stack, 'oai', {});
 
     new MicroAppsCF(stack, 'construct', {
-      bucketAppsOriginApp: new cforigins.S3Origin(bucket, {
+      bucketAppsOriginApp: cforigins.S3BucketOrigin.withOriginAccessIdentity(bucket, {
         customHeaders: {
           'x-microapps-origin': 'app',
         },
         originAccessIdentity: oai,
       }),
-      bucketAppsOriginS3: new cforigins.S3Origin(bucket, {
+      bucketAppsOriginS3: cforigins.S3BucketOrigin.withOriginAccessIdentity(bucket, {
         customHeaders: {
           'x-microapps-origin': 's3',
         },

--- a/packages/microapps-cdk/test/MicroAppsEdgeToOrigin.spec.ts
+++ b/packages/microapps-cdk/test/MicroAppsEdgeToOrigin.spec.ts
@@ -50,8 +50,7 @@ describe('MicroAppsEdgeToOrigin', () => {
       expect(construct.edgeToOriginFunction).toBeDefined();
       expect(construct.edgeToOriginLambdas).toBeDefined();
       expect(construct.node).toBeDefined();
-      // I guess this is 2 for EdgeFunction even though only 1 is created?
-      Template.fromStack(stack).resourceCountIs('AWS::Lambda::Function', 2);
+      Template.fromStack(stack).resourceCountIs('AWS::Lambda::Function', 1);
     });
 
     it('works with params', () => {
@@ -70,9 +69,7 @@ describe('MicroAppsEdgeToOrigin', () => {
       expect(construct.edgeToOriginFunction).toBeDefined();
       expect(construct.edgeToOriginLambdas).toBeDefined();
       expect(construct.node).toBeDefined();
-      // I guess this is 2 for EdgeFunction even though only 1 is created?
-      // (probably log retention lambda)
-      Template.fromStack(stack).resourceCountIs('AWS::Lambda::Function', 2);
+      Template.fromStack(stack).resourceCountIs('AWS::Lambda::Function', 1);
       Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function', {
         FunctionName: 'my-asset-name-root-edge-to-origin-some-suffix',
       });

--- a/packages/microapps-cdk/test/MicroAppsSvcs.spec.ts
+++ b/packages/microapps-cdk/test/MicroAppsSvcs.spec.ts
@@ -24,6 +24,6 @@ describe('MicroAppsSvcs', () => {
     expect(construct.table).toBeDefined();
 
     Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function', {});
-    Template.fromStack(stack).resourceCountIs('AWS::Lambda::Function', 2);
+    Template.fromStack(stack).resourceCountIs('AWS::Lambda::Function', 1);
   });
 });


### PR DESCRIPTION
## Summary

I followed up on the CDK deploy deprecation warnings that were discovered after the earlier CLI/packaging work had already been merged.

This PR:
- replaces deprecated `aws_cloudfront_origins.S3Origin` usage with `S3BucketOrigin.withOriginAccessIdentity(...)`
- replaces deprecated Lambda `logRetention` usage with explicit CloudWatch log groups
- updates the `microapps-cdk` public API/docs to use `aws_cloudfront.IOrigin`

## Verification

I verified this works by running:
- `pnpm exec jest packages/microapps-cdk/test/MicroAppsCF.spec.ts packages/microapps-cdk/test/MicroAppsS3.spec.ts --runInBand`
- `pnpm build`
